### PR TITLE
avoid unnecessary home page requests and append slash for home page

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
 import useLightningState from "hooks/useLightningState";
@@ -15,6 +15,12 @@ export default function LightningAppRoutes() {
   // Just use the first component as the home route
   const homeRoute = layoutFor(lightningState.data!).find(() => true);
 
+  const homePage = useMemo(
+    () =>
+      homeRoute?.path !== undefined && <Route index element={<Navigate replace to={`/view/${homeRoute.path}/`} />} />,
+    [homeRoute?.path],
+  );
+
   return (
     <Routes>
       {lightningState.isLoading && <Route path="*" element={<div>Lightning is initializing...</div>} />}
@@ -22,7 +28,7 @@ export default function LightningAppRoutes() {
       {runtime === Runtime.local && <Route path="/admin" element={<AdminView />}></Route>}
 
       <Route path="/view" element={<AppView />}>
-        {homeRoute !== undefined && <Route index element={<Navigate replace to={`/view/${homeRoute.path}`} />} />}
+        {homePage}
         {layoutFor(lightningState.data!).map(route => (
           <Route
             path={encodeURIComponent(route.path)}

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -17,7 +17,12 @@ export default function LightningAppRoutes() {
 
   const homePage = useMemo(
     () =>
-      homeRoute?.path !== undefined && <Route index element={<Navigate replace to={`/view/${homeRoute.path}/`} />} />,
+      homeRoute?.path !== undefined && (
+        <Route
+          index
+          element={<Navigate replace to={`/view/${homeRoute.path}${homeRoute.path.endsWith("/") ? "" : "/"}`} />}
+        />
+      ),
     [homeRoute?.path],
   );
 


### PR DESCRIPTION
# What does this PR do?

https://user-images.githubusercontent.com/23050213/183494169-de824d3c-b150-4dd3-b6de-89d54d9478fc.mov


memoize homepage iframe, so we don't have to fetch it for every change in lightning state

i think our webserver also appends a slash for requests.

## Limitations

Fill in any limitations/negative changes this PR introduces.

## Test Plan

Write any specific testing instructions for the reviewers.

## Submit checklist

- [ ] I manually QAed this PR in my local environment
- [ ] I wrote new tests
- [ ] My PR is focused
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR
- [ ] I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- [ ] My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
      positions
