### PR TITLE
fix(tabs): tabs navigation should rely only on the path

### DIFF
--- a/src/components/ComponentTabs.tsx
+++ b/src/components/ComponentTabs.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Tabs } from "design-system/components";
 
 import useLightningState from "hooks/useLightningState";
@@ -22,7 +20,7 @@ export default function ComponentTabs() {
   const tabItems = routes.map(route => {
     return {
       title: route.name.toUpperCase(),
-      href: `/view/${encodeURIComponent(route.name)}`,
+      path: `/view/${encodeURIComponent(route.name)}`,
     };
   });
 

--- a/src/design-system/components/tabs/index.tsx
+++ b/src/design-system/components/tabs/index.tsx
@@ -20,7 +20,7 @@ type StaticTabItem = {
 };
 
 type NavigableTabItem = {
-  href: string;
+  path: string;
   content?: ReactNode;
 };
 
@@ -58,15 +58,14 @@ const Tabs = ({ divider = true, ...props }: TabsProps) => {
   };
 
   const hasContent = props.tabItems.some((tabItem: any) => typeof tabItem.content !== "undefined");
-  const locationUri = location.pathname + location.hash + location.search;
-  const hrefIndex = props.tabItems.findIndex((tabItem: any) => tabItem.href === locationUri);
+  const pathIndex = props.tabItems.findIndex((tabItem: any) => tabItem.path === location.pathname);
 
   useEffect(() => {
-    const newSelectedTab = hrefIndex !== -1 ? hrefIndex : props.tabItems.findIndex(tabItem => !tabItem.disabled);
+    const newSelectedTab = pathIndex !== -1 ? pathIndex : props.tabItems.findIndex(tabItem => !tabItem.disabled);
     setSelectedTab(newSelectedTab);
     props.onTabChanged?.(newSelectedTab);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to call this on onTabChanged change
-  }, [hrefIndex, locationUri]);
+  }, [pathIndex, location.pathname]);
 
   return (
     <Box>
@@ -83,7 +82,7 @@ const Tabs = ({ divider = true, ...props }: TabsProps) => {
               label={tabItem.title}
               variant={props.variant}
               disabled={tabItem.disabled}
-              onClick={tabItem.href && navigateHandler(tabItem.href, index)}
+              onClick={tabItem.path && navigateHandler(tabItem.path, index)}
             />
           );
 


### PR DESCRIPTION
# What does this PR do?

This PR makes tabs navigation rely on the `/path` instead of the `/path#hash?search`. We only use it with paths at the moment and having it rely on hash and search makes using hash and search for other purposes impossible.

## Limitations

This is a breaking change and will require refactoring once the dep is updated.

## Test Plan

Everything should continue to work.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests [for a bug or new feature]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
