### PR TITLE
fix(Tabs): make Tabs prerenderable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug, help wanted
-assignees: ''
+assignees: ""
 ---
 
 ## 🐛 Bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: enhancement, help wanted
-assignees: ''
+assignees: ""
 ---
 
 ## 🚀 Feature

--- a/src/design-system/components/tabs/index.tsx
+++ b/src/design-system/components/tabs/index.tsx
@@ -1,7 +1,7 @@
 import { MouseEventHandler, ReactNode, useEffect, useState } from "react";
 
-import { TabContext, TabPanel } from "@mui/lab";
-import { Tab as MuiTab, TabProps as MuiTabProps, Tabs as MuiTabs } from "@mui/material";
+import { TabContext } from "@mui/lab";
+import { BoxProps, Tab as MuiTab, TabProps as MuiTabProps, Tabs as MuiTabs } from "@mui/material";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { Tooltip } from "..";
@@ -110,14 +110,35 @@ const Tabs = ({
       {hasContent && (
         <Box paddingTop={3} paddingBottom={1.5} sx={sxContent}>
           {tabItems.map((tabItem, index) => (
-            <TabPanel sx={{ padding: 0, background: "white" }} key={index} value={index.toString()}>
-              {prerenderTabs || selectedTab === index ? tabItem.content : null}
-            </TabPanel>
+            <PrerenderableTabPanel
+              sx={{ padding: 0, background: "white" }}
+              key={index}
+              index={index}
+              selectedIndex={selectedTab}
+              prerender={prerenderTabs}>
+              {tabItem.content}
+            </PrerenderableTabPanel>
           ))}
         </Box>
       )}
     </TabContext>
   );
 };
+
+type PrerenderableTabPanelProps = {
+  sx?: BoxProps["sx"];
+  children: ReactNode;
+  selectedIndex: number;
+  index: number;
+  prerender?: boolean;
+};
+
+function PrerenderableTabPanel({ sx, children, selectedIndex, index, prerender }: PrerenderableTabPanelProps) {
+  return (
+    <Box role={"tabpanel"} sx={sx} hidden={selectedIndex !== index}>
+      {prerender || selectedIndex === index ? children : null}
+    </Box>
+  );
+}
 
 export default Tabs;


### PR DESCRIPTION
# What does this PR do?

This PR makes tabs prerenderable

<img width="1468" alt="image" src="https://user-images.githubusercontent.com/4187729/215508141-969fc4a1-f452-480c-8df4-2ca47bc13d5e.png">

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/4187729/215508272-f5d13b2a-e9ab-40b6-b078-5f392b03b40e.png">

## Limitations

N/A

## Test Plan

Manual validation in storybook

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
