### PR TITLE
fix(Snackbar): make Snackbar persistence configurable

### DIFF
--- a/src/design-system/components/snackbar-provider/index.tsx
+++ b/src/design-system/components/snackbar-provider/index.tsx
@@ -6,7 +6,7 @@ import { Box } from "..";
 import Alert, { AlertProps } from "../alert";
 import { EnqueueSnackbarProps, useSnackbar } from "./useSnackbar";
 
-const autoHideDuration = 1000 * 60 * 60 * 12;
+const AUTO_HIDE_DURATION_MS = 1000 * 5;
 
 const AlertRef = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
   return (
@@ -52,7 +52,7 @@ export default function SnackbarProvider(props: SnackbarProviderProps) {
   return (
     <NotistackSnackbarProvider
       maxSnack={5}
-      autoHideDuration={autoHideDuration}
+      autoHideDuration={AUTO_HIDE_DURATION_MS}
       anchorOrigin={{
         vertical: "bottom",
         horizontal: "left",

--- a/src/design-system/components/snackbar-provider/snackbar.stories.tsx
+++ b/src/design-system/components/snackbar-provider/snackbar.stories.tsx
@@ -1,10 +1,8 @@
-import React from "react";
-
 import { Box } from "@mui/material";
 import Button from "design-system/components/button";
 import { useSnackbar } from "design-system/components/snackbar-provider/useSnackbar";
 
-const Demo = ({ action, ...args }: { action: boolean }) => {
+const Demo = ({ action, persist, ...args }: { action: boolean; persist: boolean }) => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
   const actionComponent = action
@@ -15,7 +13,7 @@ const Demo = ({ action, ...args }: { action: boolean }) => {
       <Button
         text={"Open snackbar"}
         onClick={() => {
-          enqueueSnackbar({ action: actionComponent, ...args });
+          enqueueSnackbar({ action: actionComponent, ...args }, { persist });
         }}
       />
     </Box>
@@ -46,6 +44,10 @@ export default {
       control: "text",
     },
     action: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    persist: {
       defaultValue: false,
       control: "boolean",
     },

--- a/src/design-system/components/snackbar-provider/useSnackbar.ts
+++ b/src/design-system/components/snackbar-provider/useSnackbar.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { useSnackbar as useNotistackSnackbar } from "notistack";
+import { OptionsObject, useSnackbar as useNotistackSnackbar } from "notistack";
 
 import { AlertProps } from "../alert";
 
@@ -11,8 +11,8 @@ export function useSnackbar() {
   const { enqueueSnackbar: enqueueNotistackSnackbar, closeSnackbar } = useNotistackSnackbar();
 
   const enqueueSnackbar = useCallback(
-    (props: EnqueueSnackbarProps) => {
-      return enqueueNotistackSnackbar(props);
+    (props: EnqueueSnackbarProps, options?: OptionsObject) => {
+      return enqueueNotistackSnackbar(props, options);
     },
     [enqueueNotistackSnackbar],
   );


### PR DESCRIPTION
# What does this PR do?

This PR reintroduces the logic that made snackbars auto-disappear in 5 seconds and allows passing "{ persist: true }" option to make them persist.

https://user-images.githubusercontent.com/4187729/221838038-43f019c0-a4dc-4c47-8827-f64964ff0d02.mov

## Limitations

N/A

## Test Plan

Manual validation in Storybook.

## Submit checklist

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
