### PR TITLE
fix(ui): update word break rules for snackbar

### DIFF
--- a/src/design-system/components/snackbar-provider/index.tsx
+++ b/src/design-system/components/snackbar-provider/index.tsx
@@ -16,6 +16,9 @@ const AlertRef = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
         "backgroundColor": "transparent",
         "& .MuiAlert-root": {
           boxShadow: 2,
+          overflowWrap: "break-word",
+          wordWrap: "break-word",
+          wordBreak: "break-word",
         },
       }}>
       <Alert {...props} />


### PR DESCRIPTION


# What does this PR do?

Update to snackbar word-break property to avoid unnecessary splitting of words in snackbar elements- still allows breaking of single words that would exceed container width (e.g. super long filenames)

Before:
<img width="561" alt="Screen+Shot+2023-03-02+at+12 23 33+PM" src="https://user-images.githubusercontent.com/215949/222505041-8b025772-720f-40c8-b034-8948f6700626.png">

After:
<img width="561" alt="Screen+Shot+2023-03-02+at+12 24 30+PM" src="https://user-images.githubusercontent.com/215949/222505094-e2db77dd-4d5c-4c89-9000-17c0b4b33083.png">

## Limitations

N/A

## Test Plan

Manual validation.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
