### PR TITLE
fix(ui): ensure that prerendered tabs have a size offscreen

### DIFF
--- a/src/design-system/components/tabs/index.spec.tsx
+++ b/src/design-system/components/tabs/index.spec.tsx
@@ -1,0 +1,66 @@
+import { mount } from "@cypress/react";
+
+import { PrerenderableTabPanel } from ".";
+
+describe("PrerenderableTabPanel", () => {
+  /**
+   * Having "display: none" or "visibility: hidden" or having size smaller than 4px in any dimension
+   * disables a lot of web preloading features. We want to avoid this for our prerendered tabs.
+   */
+  it(`doesn't have neither "display: none", nor "visibility: hidden" and has min size if it's inactive`, () => {
+    mount(
+      <PrerenderableTabPanel index={0} selectedIndex={1}>
+        tab content
+      </PrerenderableTabPanel>,
+    );
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "display", "none");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "visibility", "hidden");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("have.css", "opacity", "0");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("have.css", "zIndex", "-100500");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("have.css", "position", "absolute");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("have.css", "minHeight", "50px");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("have.css", "minWidth", "50px");
+  });
+
+  it(`doesn't have any hiding styles and min size if it's active`, () => {
+    mount(
+      <PrerenderableTabPanel index={0} selectedIndex={0}>
+        tab content
+      </PrerenderableTabPanel>,
+    );
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "display", "none");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "visibility", "hidden");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "opacity", "0");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "zIndex", "-100500");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "position", "absolute");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "minHeight", "50px");
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.have.css", "minWidth", "50px");
+  });
+
+  it(`renders content if it's inactive and prerender is enabled`, () => {
+    mount(
+      <PrerenderableTabPanel index={0} selectedIndex={1} prerender>
+        tab content
+      </PrerenderableTabPanel>,
+    );
+    cy.get("[data-testid=prerenderable-tab-panel]").should("contain", "tab content");
+  });
+
+  it(`doesn't render content if it's inactive and prerender is disabled`, () => {
+    mount(
+      <PrerenderableTabPanel index={0} selectedIndex={1}>
+        tab content
+      </PrerenderableTabPanel>,
+    );
+    cy.get("[data-testid=prerenderable-tab-panel]").should("not.contain", "tab content");
+  });
+
+  it(`renders content if it's active`, () => {
+    mount(
+      <PrerenderableTabPanel index={0} selectedIndex={0}>
+        tab content
+      </PrerenderableTabPanel>,
+    );
+    cy.get("[data-testid=prerenderable-tab-panel]").should("contain", "tab content");
+  });
+});

--- a/src/design-system/components/tabs/index.tsx
+++ b/src/design-system/components/tabs/index.tsx
@@ -162,9 +162,17 @@ type PrerenderableTabPanelProps = {
   prerender?: boolean;
 };
 
-function PrerenderableTabPanel({ sx, children, selectedIndex, index, prerender }: PrerenderableTabPanelProps) {
+export function PrerenderableTabPanel({ sx, children, selectedIndex, index, prerender }: PrerenderableTabPanelProps) {
   return (
-    <Box role={"tabpanel"} sx={sx} hidden={selectedIndex !== index}>
+    <Box
+      data-testid={"prerenderable-tab-panel"}
+      role={"tabpanel"}
+      sx={{
+        ...sx,
+        ...(selectedIndex !== index
+          ? { zIndex: -100500, opacity: 0, position: "absolute", minHeight: "50px", minWidth: "50px" }
+          : undefined),
+      }}>
       {prerender || selectedIndex === index ? children : null}
     </Box>
   );


### PR DESCRIPTION
# What does this PR do?

This PR fixes inactive tab prerendering issues in the `Tabs` component.

## Limitations

N/A

## Test Plan

Manual validation + autotests.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [x] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
