### PR TITLE
fix: remove kebab props from MUI components

### DIFF
--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -135,7 +135,6 @@ const TextField = React.forwardRef(
             endAdornment={
               loading ? <CircularProgress thickness={2} color="inherit" size={20} /> : status && statusIcon[status]
             }
-            // @ts-ignore -webkit-appearance and -moz-appearance
             sx={{
               "font": INPUT_TEXT_FONT,
               "height": "36px",
@@ -145,11 +144,11 @@ const TextField = React.forwardRef(
                 marginRight: `${marginRightPx}px`,
               },
               "input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button": {
-                "-webkit-appearance": "none",
-                "margin": 0 /* <-- Apparently some margin are still there even though it's hidden */,
+                WebkitAppearance: "none",
+                margin: 0 /* <-- Apparently some margin are still there even though it's hidden */,
               },
               "input[type=number]": {
-                "-moz-appearance": "textfield" /* Firefox */,
+                MozAppearance: "textfield" /* Firefox */,
               },
               "&.MuiInputBase-colorPrimary:hover .MuiOutlinedInput-notchedOutline": {
                 borderColor: (theme: any) => theme.palette[status ?? "primary"].main,


### PR DESCRIPTION
# What does this PR do?

Cleans up CSS props to not include `--moz` and `--webkit` CSS props.

## Limitations

No.

## Test Plan

Manual validation.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
