### PR TITLE
dark theme update for forms/modal content

### DIFF
--- a/src/design-system/components/dialog/Dialog.tsx
+++ b/src/design-system/components/dialog/Dialog.tsx
@@ -8,6 +8,10 @@ const Dialog = ({ PaperProps, ...props }: DialogProps) => (
       ...PaperProps,
       style: { borderRadius: "8px", ...PaperProps?.style },
     }}
+    sx={{
+      "color": (theme: any) => theme.palette.text.primary,
+      ".MuiFormControl-root p, .MuiButton-containedGrey": { color: (theme: any) => theme.palette.text.primary },
+    }}
     {...props}
   />
 );

--- a/src/design-system/components/dialog/DialogFormActions.tsx
+++ b/src/design-system/components/dialog/DialogFormActions.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react";
+
+import TextField from "design-system/components/text-field";
+
+import { Dialog, DialogActions, DialogContent, DialogTitle } from ".";
+import { Box, Stack, Typography } from "..";
+import { DialogProps } from "./Dialog";
+
+export type DialogFormActionsProps = {
+  title: string;
+  message?: string;
+  description?: string;
+  imageSrc: string;
+  actions: ReactNode;
+  onClose: () => void;
+} & Pick<DialogProps, "open">;
+
+export default function DialogFormActions({ ...props }: DialogFormActionsProps) {
+  return (
+    <Dialog open={props.open} onClose={props.onClose}>
+      <DialogTitle text={props.title} onCloseClick={props.onClose} />
+      <DialogContent>
+        <Stack
+          width={"400px"}
+          justifyContent={"center"}
+          alignItems={"center"}
+          spacing={2.5}
+          sx={{ ".MuiDialogActions-root, .MuiOutlinedInput-root, .MuiFormControl-root": { width: "100%" } }}>
+          <TextField
+            helperText="Helper Text"
+            label="Label"
+            onChange={() => {}}
+            placeholder="Placeholder"
+            size="medium"
+            suffix=""
+            tooltip="Tooltip message"
+            type="text"
+          />
+          <DialogActions>{props.actions}</DialogActions>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/design-system/components/dialog/DialogFormActions.tsx
+++ b/src/design-system/components/dialog/DialogFormActions.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import TextField from "design-system/components/text-field";
 
 import { Dialog, DialogActions, DialogContent, DialogTitle } from ".";
-import { Box, Stack, Typography } from "..";
+import { Stack } from "..";
 import { DialogProps } from "./Dialog";
 
 export type DialogFormActionsProps = {

--- a/src/design-system/components/dialog/dialog.stories.tsx
+++ b/src/design-system/components/dialog/dialog.stories.tsx
@@ -4,6 +4,7 @@ import { DialogActions, DialogContent, DialogTitle } from "design-system/compone
 import Dialog, { DialogProps } from "design-system/components/dialog/Dialog";
 
 import { Box, Stack } from "..";
+import DialogFormActions, { DialogFormActionsProps } from "./DialogFormActions";
 import DialogImageActions, { DialogImageActionsProps } from "./DialogImageActions";
 import DialogNotification, { DialogNotificationProps } from "./DialogNotification";
 import phantomSrc from "./phantom.svg";
@@ -154,3 +155,24 @@ const NotificationTemplate: ComponentStory<any> = (args: DialogNotificationProps
 
 export const Notifications = NotificationTemplate.bind({});
 Notifications.parameters = { controls: { include: ["open", "variant", "message", "description"] } };
+
+const formActions = {
+  submit: (
+    <Stack width={"100%"} direction={"row"} justifyContent={"space-between"}>
+      <Button text="Cancel" color={"grey"} onClick={buttonOnClickHandler} />
+      <Button text="Submit" onClick={buttonOnClickHandler} fullWidth />
+    </Stack>
+  ),
+};
+
+const FormActionsTemplate: ComponentStory<any> = (args: DialogFormActionsProps) => {
+  const actions = (
+    <Stack width={"100%"} direction={"row"} spacing={1}>
+      {formActions.submit}
+    </Stack>
+  );
+  return <DialogFormActions {...args} actions={actions}></DialogFormActions>;
+};
+
+export const FormActions = FormActionsTemplate.bind({});
+FormActions.parameters = { controls: { include: ["open", "variant", "message", "description"] } };


### PR DESCRIPTION
# What does this PR do?

<img width="534" alt="Screen+Shot+2023-03-14+at+11 56 59+AM" src="https://user-images.githubusercontent.com/215949/225063308-d36c0aba-e90a-4aaa-abe1-fb073c8c40b9.png">

Add appropriate color vars for dark theme modals to ensure readable contrast.

## Limitations

Some values are hardcoded/overridden and will need to be addressed on a case-by-case basis.

## Test Plan

Manual validation.

## Submit checklist

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
