### PR TITLE
fix(ui): update tooltip default delay & storybook url fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ will download and include the `lightning-ui` that is in the bucket above
 
 ## Design System Documentation
 
-https://congenial-chainsaw-5d118edf.pages.github.io/?path=/story/introduction--page
+https://lightning-ai.github.io/lightning-ui/?path=/story/introduction--page
 
 **Run locally**
 

--- a/src/design-system/components/tooltip/index.tsx
+++ b/src/design-system/components/tooltip/index.tsx
@@ -16,8 +16,8 @@ const Tooltip = ({
   placement = "top",
   width,
   interactive = true,
-  delay = 1500,
-  enterNextDelay = 500,
+  delay = 200,
+  enterNextDelay = 200,
 }: TooltipProps) => {
   return (
     <MuiTooltip


### PR DESCRIPTION
# What does this PR do?

Tooltip delay was too slow (1.5s) updated to 200ms, fixed broken storybook url in readme

![Kapture 2023-03-14 at 16 12 13](https://user-images.githubusercontent.com/215949/225125394-27ec8f0b-c00e-4546-9423-560d68d12b4b.gif)



## Limitations

None.

## Test Plan

N/A

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [x] I wrote new tests \[for a bug or new feature\]
- [ ] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
