### PR TITLE
feature: add outlined button prop/styles, fix dark mode contrast issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug, help wanted
-assignees: ''
+assignees: ""
 ---
 
 ## 🐛 Bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: enhancement, help wanted
-assignees: ''
+assignees: ""
 ---
 
 ## 🚀 Feature

--- a/src/design-system/components/button/button.stories.tsx
+++ b/src/design-system/components/button/button.stories.tsx
@@ -43,6 +43,10 @@ export default {
       control: "boolean",
       defaultValue: false,
     },
+    pill: {
+      control: "boolean",
+      defaultValue: false,
+    },
     size: {
       options: ["medium", "small"],
       control: "select",

--- a/src/design-system/components/button/button.stories.tsx
+++ b/src/design-system/components/button/button.stories.tsx
@@ -39,6 +39,10 @@ export default {
       control: "boolean",
       defaultValue: false,
     },
+    bordered: {
+      control: "boolean",
+      defaultValue: false,
+    },
     size: {
       options: ["medium", "small"],
       control: "select",

--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -18,6 +18,7 @@ export type ButtonProps = {
   children?: ReactNode;
   cursor?: boolean;
   bordered?: boolean;
+  pill?: boolean;
 } & Pick<MuiButtonProps, "disabled" | "fullWidth" | "variant" | "href" | "onClick" | "size">;
 
 const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
@@ -32,6 +33,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
   const variant = isTextVariant ? props.variant : "contained";
   const isSmallSize = props.size === "small";
   const height = (isSmallSize && "28px") || "36px";
+  const isPill = props.pill;
   const color = (theme: any) => {
     return (isGreyColor && theme.palette.common.black) || theme.palette.common.white;
   };
@@ -97,6 +99,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
           color,
           backgroundColor,
           background,
+          "borderRadius": isPill ? "20px" : "8px",
           ...(isGreyColor &&
             isDark && {
               "background": theme.palette.grey[70],
@@ -268,11 +271,17 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
             backgroundColor,
           },
           "& .MuiButton-startIcon": {
-            color: isGreyColor ? (theme: any) => theme.palette.grey[20] : "inherit",
+            color: "inherit",
           },
           "& .MuiButton-endIcon": {
-            color: isGreyColor ? (theme: any) => theme.palette.grey[20] : "inherit",
+            color: "inherit",
           },
+          ...(isGreyColor &&
+            !isBorderedVariant && {
+              "&:hover": {
+                backgroundColor: theme.palette.grey[40],
+              },
+            }),
           ...onlyIconStyle,
         }}
         {...props}

--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -1,7 +1,8 @@
-import { MouseEventHandler, ReactNode } from "react";
+import { MouseEventHandler, ReactNode, useRef } from "react";
 
 import { ArrowDropDownRounded } from "@mui/icons-material";
 import { Button as MuiButton, ButtonProps as MuiButtonProps } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
 
 import { Box, CircularProgress, Tooltip } from "../";
@@ -16,13 +17,18 @@ export type ButtonProps = {
   tooltip?: TooltipProps["title"];
   children?: ReactNode;
   cursor?: boolean;
+  bordered?: boolean;
 } & Pick<MuiButtonProps, "disabled" | "fullWidth" | "variant" | "href" | "onClick" | "size">;
 
 const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
   const isTextVariant = props.variant === "text";
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const isCursorVariant = props.cursor;
+  const isBorderedVariant = props.bordered;
   const isPrimaryColor = !isTextVariant && (typeof props.color === "undefined" || props.color?.startsWith("primary"));
-  const isGreyColor = isTextVariant || props.color?.startsWith("grey");
+  const isGreyColor = isTextVariant || props.color?.startsWith("grey") || isBorderedVariant;
   const variant = isTextVariant ? props.variant : "contained";
   const isSmallSize = props.size === "small";
   const height = (isSmallSize && "28px") || "36px";
@@ -34,6 +40,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
   };
   const backgroundColor = (theme: any) => {
     if (variant === "text") return "transparent";
+    if (isBorderedVariant) return theme.palette.grey["10"];
     if (isGreyColor) return theme.palette.grey["20"];
     if (isPrimaryColor) return theme.palette.primary;
     return theme.palette[props.color].main;
@@ -60,6 +67,14 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
     }
   };
 
+  const mouseOverHandler = (event: any) => {
+    let path = buttonRef?.current?.querySelector("svg path") as SVGPathElement;
+    let total = path?.getTotalLength();
+    if (total) {
+      path?.style.setProperty("--path-length", total.toString() + "px");
+    }
+  };
+
   const onClickHandler = !props.onClick && href ? navigateHandler(href) : props.onClick;
   const hasNoText = typeof props.text === "undefined" || props.text === "";
   const onlyIconStyle = hasNoText && {
@@ -81,8 +96,105 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
           color,
           backgroundColor,
           background,
+          ...(isBorderedVariant && {
+            "position": "relative",
+            "overflow": "hidden",
+            "transition": "0.3s ease-in-out",
+            "borderRadius": "5px",
+            "background": "transparent",
+            "color": (theme: any) => theme.palette.grey[70],
+            "boxShadow": "inset 0 0 0 1px, 0 0 0 0, 0 0 0 0",
+            "fontWeight": "500",
+            "div.MuiBox-root": {
+              transition: "inherit",
+              fontWeight: "inherit",
+            },
+            "&:before, &:after": {
+              content: "''",
+              position: "absolute",
+              borderRadius: "4px",
+            },
+            "&:before": {
+              width: "150%",
+              height: "auto",
+              transition: "opacity 0.4s ease-in-out",
+              opacity: "0",
+              aspectRatio: "1/1",
+              top: "50%",
+              left: "-25%",
+              transform: "translateY(-50%) rotate(0deg)",
+              zIndex: "-2",
+              animation: "btnRotate 2s cubic-bezier(0.65, 0.25, 0.75, 1) infinite",
+              animationPlayState: "paused",
+              background:
+                "conic-gradient(from 0.25turn at 50% 50%,#7b2fe4,10deg,transparent,200deg,transparent,320deg,#ad1fdd),conic-gradient(from 0.75turn at 50% 50%,#7b2fe4,10deg,transparent,320deg,#6005ff)",
+            },
+            "@keyframes btnRotate": {
+              "100%": {
+                transform: "translateY(-50%) rotate(360deg)",
+              },
+            },
+            "&:after": {
+              width: "calc(100% - 3px)",
+              height: "calc(100% - 3px)",
+              top: "1.5px",
+              left: "1.5px",
+              zIndex: "-1",
+              background: isDark ? "#000" : "#fff",
+              transition: "0.3s ease-in-out",
+              boxShadow: isDark
+                ? "inset 0 0 2px -5px #000, inset 0 0 8px -10px #222"
+                : "inset 0 0 2px -5px #fff, inset 0 0 8px -10px #fff",
+            },
+            "&:hover": {
+              "backgroundColor": "transparent",
+              "boxShadow": isDark
+                ? "inset 0 0 0 2px transparent, 0 0 0 1px #000, 0 1px 5px 0 rgba(0, 0, 0, 0.15)"
+                : "inset 0 0 0 2px transparent, 0 0 0 1px #fff, 0 1px 5px 0 rgba(0, 0, 0, 0.15)",
+              "color": isDark ? (theme: any) => theme.palette.common.white : (theme: any) => theme.palette.primary[70],
+              "div.MuiBox-root": {
+                color: isDark ? (theme: any) => theme.palette.common.white : (theme: any) => theme.palette.primary[70],
+              },
+              "&:before": {
+                opacity: "1",
+                animationPlayState: "running",
+              },
+              "&:after": {
+                boxShadow: isDark
+                  ? "inset 0 0 2px 1px #000, inset 0 0 8px 2px #222"
+                  : "inset 0 0 2px 1px #fff, inset 0 0 8px 2px #fff",
+              },
+              "span:not(.MuiButton-endIcon) svg path": {
+                "strokeDashoffset": "var(--path-length)",
+                "strokeDasharray": "var(--path-length)",
+                "strokeWidth": "0.5px",
+                "animation": "drawSvg 1.5s ease-in-out forwards",
+                "stroke": "currentcolor",
+                "fill": "transparent",
+                "@keyframes drawSvg": {
+                  "50%": {
+                    strokeDashoffset: "0px",
+                    fill: "transparent",
+                    strokeWidth: "1px",
+                    stroke: (theme: any) => theme.palette.primary[70],
+                  },
+                  "100%": {
+                    strokeDashoffset: "0px",
+                    fill: isDark
+                      ? (theme: any) => theme.palette.common.white
+                      : (theme: any) => theme.palette.primary[70],
+                    stroke: isDark
+                      ? (theme: any) => theme.palette.common.white
+                      : (theme: any) => theme.palette.primary[70],
+                    strokeWidth: "0px",
+                  },
+                },
+              },
+            },
+          }),
           ...(!isTextVariant &&
-            isPrimaryColor && {
+            isPrimaryColor &&
+            !isBorderedVariant && {
               "transition": "0.3s ease-in-out",
               "backgroundSize": "100% 100%",
               "backgroundPosition": "50% 50%",
@@ -91,36 +203,37 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
                 filter: "brightness(1.1)",
               },
             }),
-          ...(isCursorVariant && {
-            "position": "relative",
-            "overflow": "hidden",
-            "> div": {
-              pointerEvents: "none",
-              position: "relative",
-              zIndex: 1,
-            },
-            "&:hover": {
-              "&:before": {
-                opacity: "1",
+          ...(isCursorVariant &&
+            !isBorderedVariant && {
+              "position": "relative",
+              "overflow": "hidden",
+              "> div": {
+                pointerEvents: "none",
+                position: "relative",
+                zIndex: 1,
               },
-            },
-            "&:before": {
-              opacity: "0",
-              transition: "opacity 0.3s ease-in-out, transform 1s cubic-bezier(0.175, 0.885, 0.32, 1.275)",
-              content: "''",
-              position: "absolute",
-              pointerEvents: "none",
-              top: 0,
-              left: 0,
-              width: "15px",
-              height: "15px",
-              borderRadius: "100%",
-              filter: "blur(8px)",
-              transform: "translate(calc(var(--x) - 7.5px), calc(var(--y) - 5px)) translateZ(0px)",
-              background: (theme: any) => theme.palette.secondary[40],
-              zIndex: "0",
-            },
-          }),
+              "&:hover": {
+                "&:before": {
+                  opacity: "1",
+                },
+              },
+              "&:before": {
+                opacity: "0",
+                transition: "opacity 0.3s ease-in-out, transform 1s cubic-bezier(0.175, 0.885, 0.32, 1.275)",
+                content: "''",
+                position: "absolute",
+                pointerEvents: "none",
+                top: 0,
+                left: 0,
+                width: "15px",
+                height: "15px",
+                borderRadius: "100%",
+                filter: "blur(8px)",
+                transform: "translate(calc(var(--x) - 7.5px), calc(var(--y) - 5px)) translateZ(0px)",
+                background: (theme: any) => theme.palette.secondary[40],
+                zIndex: "0",
+              },
+            }),
           "&.Mui-disabled": {
             opacity: isGreyColor ? 0.3 : 0.5,
             color,
@@ -142,7 +255,9 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
         endIcon={arrow ? <ArrowDropDownRounded /> : undefined}
         variant={variant}
         onClick={onClickHandler}
-        onMouseMove={isCursorVariant ? mouseMoveHandler : undefined}
+        onMouseMove={isCursorVariant && !isBorderedVariant ? mouseMoveHandler : undefined}
+        onMouseOver={isBorderedVariant ? mouseOverHandler : undefined}
+        ref={buttonRef}
         href={href}>
         {!!props.text && (
           <Box fontStyle={"normal"} fontSize={"14px"} lineHeight={"20px"}>

--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -249,6 +249,19 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
                 zIndex: "0",
               },
             }),
+
+          ...(isTextVariant &&
+            isDark && {
+              "color": theme.palette.grey[100],
+              "background": "transparent",
+              "&:hover": {
+                "background": theme.palette.grey[70],
+                "color": theme.palette.grey[10],
+                "svg path": {
+                  fill: theme.palette.grey[10],
+                },
+              },
+            }),
           "&.Mui-disabled": {
             opacity: isGreyColor ? 0.3 : 0.5,
             color,

--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -21,7 +21,7 @@ export type ButtonProps = {
 } & Pick<MuiButtonProps, "disabled" | "fullWidth" | "variant" | "href" | "onClick" | "size">;
 
 const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
-  const theme = useTheme();
+  const theme: any = useTheme();
   const isDark = theme.palette.mode === "dark";
   const isTextVariant = props.variant === "text";
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -87,6 +87,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
       margin: 0,
     },
   };
+
   return (
     <Tooltip title={props.tooltip}>
       <MuiButton
@@ -96,13 +97,30 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
           color,
           backgroundColor,
           background,
+          ...(isGreyColor &&
+            isDark && {
+              "background": theme.palette.grey[70],
+              "& .MuiButton-startIcon": {
+                transition: "0.2s ease-in-out",
+              },
+              "&:hover": {
+                "background": theme.palette.secondary[40],
+                "color": theme.palette.common.white,
+                "& .MuiButton-startIcon": {
+                  color: theme.palette.common.white,
+                },
+              },
+              "svg": {
+                fill: "currentColor",
+              },
+            }),
           ...(isBorderedVariant && {
             "position": "relative",
             "overflow": "hidden",
             "transition": "0.3s ease-in-out",
             "borderRadius": "5px",
             "background": "transparent",
-            "color": (theme: any) => theme.palette.grey[70],
+            "color": theme.palette.grey[70],
             "boxShadow": "inset 0 0 0 1px, 0 0 0 0, 0 0 0 0",
             "fontWeight": "500",
             "div.MuiBox-root": {
@@ -140,7 +158,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
               top: "1.5px",
               left: "1.5px",
               zIndex: "-1",
-              background: isDark ? "#000" : "#fff",
+              background: isDark ? theme.palette.primary[10] : "#fff",
               transition: "0.3s ease-in-out",
               boxShadow: isDark
                 ? "inset 0 0 2px -5px #000, inset 0 0 8px -10px #222"
@@ -151,15 +169,16 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
               "boxShadow": isDark
                 ? "inset 0 0 0 2px transparent, 0 0 0 1px #000, 0 1px 5px 0 rgba(0, 0, 0, 0.15)"
                 : "inset 0 0 0 2px transparent, 0 0 0 1px #fff, 0 1px 5px 0 rgba(0, 0, 0, 0.15)",
-              "color": isDark ? (theme: any) => theme.palette.common.white : (theme: any) => theme.palette.primary[70],
+              "color": isDark ? theme.palette.common.white : theme.palette.primary[70],
               "div.MuiBox-root": {
-                color: isDark ? (theme: any) => theme.palette.common.white : (theme: any) => theme.palette.primary[70],
+                color: isDark ? theme.palette.common.white : theme.palette.primary[70],
               },
               "&:before": {
                 opacity: "1",
                 animationPlayState: "running",
               },
               "&:after": {
+                background: isDark ? theme.palette.primary[20] : "#fff",
                 boxShadow: isDark
                   ? "inset 0 0 2px 1px #000, inset 0 0 8px 2px #222"
                   : "inset 0 0 2px 1px #fff, inset 0 0 8px 2px #fff",
@@ -176,16 +195,12 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
                     strokeDashoffset: "0px",
                     fill: "transparent",
                     strokeWidth: "1px",
-                    stroke: (theme: any) => theme.palette.primary[70],
+                    stroke: theme.palette.primary[70],
                   },
                   "100%": {
                     strokeDashoffset: "0px",
-                    fill: isDark
-                      ? (theme: any) => theme.palette.common.white
-                      : (theme: any) => theme.palette.primary[70],
-                    stroke: isDark
-                      ? (theme: any) => theme.palette.common.white
-                      : (theme: any) => theme.palette.primary[70],
+                    fill: isDark ? theme.palette.common.white : theme.palette.primary[70],
+                    stroke: isDark ? theme.palette.common.white : theme.palette.primary[70],
                     strokeWidth: "0px",
                   },
                 },
@@ -240,10 +255,10 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
             backgroundColor,
           },
           "& .MuiButton-startIcon": {
-            color: isGreyColor ? (theme: any) => theme.palette.grey[70] : "inherit",
+            color: isGreyColor ? (theme: any) => theme.palette.grey[20] : "inherit",
           },
           "& .MuiButton-endIcon": {
-            color: isGreyColor ? (theme: any) => theme.palette.grey[70] : "inherit",
+            color: isGreyColor ? (theme: any) => theme.palette.grey[20] : "inherit",
           },
           ...onlyIconStyle,
         }}

--- a/src/design-system/components/form-helper-text/index.tsx
+++ b/src/design-system/components/form-helper-text/index.tsx
@@ -10,7 +10,7 @@ const FormHelperText = (props: FormHelperTextProps) => (
   <Typography
     {...props}
     sx={{
-      color: "rgba(91, 94, 105, 1)",
+      color: (theme: any) => theme.palette.text.secondary,
       fontWeight: 400,
       fontStyle: "normal",
       fontSize: "12px",

--- a/src/design-system/components/form-label/index.tsx
+++ b/src/design-system/components/form-label/index.tsx
@@ -12,7 +12,7 @@ const FormLabel = ({ optional, tooltip, children }: FormLabelProps) => (
   <Stack direction={"row"} alignItems={"center"} spacing={0.5}>
     <Typography
       sx={{
-        color: "rgba(28, 28, 28, 1)",
+        color: (theme: any) => theme.palette.text.primary,
         fontWeight: 600,
         fontStyle: "normal",
         fontSize: "14px",

--- a/src/design-system/components/form-status-text/index.tsx
+++ b/src/design-system/components/form-status-text/index.tsx
@@ -13,7 +13,7 @@ const FormStatusText = (props: FormStatusTextProps) => (
       minHeight: "16px",
       height: "auto",
       padding: "8px 12px",
-      color: "rgba(28, 28, 28, 1)",
+      color: (theme: any) => theme.palette.text.secondary,
       fontWeight: 700,
       fontStyle: "normal",
       fontSize: "12px",

--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEventHandler, ReactNode, useEffect } from "react";
 
 import { CircularProgress } from "@mui/material";
 import MuiOutlinedInput, { OutlinedInputProps as MuiOutlinedInputProps } from "@mui/material/OutlinedInput";
+import { useTheme } from "@mui/material/styles";
 
 import { Box, Stack } from "..";
 import getTextWidth from "../../../shared/utils/getTextWidth";
@@ -70,6 +71,8 @@ const TextField = React.forwardRef(
     // tracking current value to be able to correctly offset the suffix
     const [valueInternal, setValueInternal] = React.useState(props.value);
     const internalRef = React.useRef<HTMLInputElement>();
+    const theme: any = useTheme();
+    const isDark = theme.palette.mode === "dark";
 
     useEffect(() => setValueInternal(props.value), [props.value]);
 
@@ -138,7 +141,7 @@ const TextField = React.forwardRef(
             sx={{
               "font": INPUT_TEXT_FONT,
               "height": "36px",
-              "backgroundColor": (theme: any) => theme.palette.background.default,
+              "backgroundColor": isDark ? theme.palette.grey["40"] : theme.palette.background.default,
               "borderRadius": type === "number" ? "6px 0 0 6px" : "6px",
               "input": {
                 marginRight: `${marginRightPx}px`,

--- a/src/design-system/theme/index.tsx
+++ b/src/design-system/theme/index.tsx
@@ -24,9 +24,7 @@ export const darkTheme = createTheme({
 
 const ThemeProvider = ({ children, colorScheme }: { children: ReactNode; colorScheme?: "light" | "dark" }) => {
   useEffect(() => {
-    colorScheme === "dark"
-      ? document.body?.style.setProperty("background", "#0e061c")
-      : document.body?.style.setProperty("background", "fff");
+    document.body?.style.setProperty("background",  colorScheme === "dark" ? darkTheme.palette.background.default : theme.palette.background.default);
   }, [colorScheme]);
   return <MuiThemeProvider theme={colorScheme === "dark" ? darkTheme : theme} children={children} />;
 };

--- a/src/design-system/theme/index.tsx
+++ b/src/design-system/theme/index.tsx
@@ -25,9 +25,9 @@ export const darkTheme = createTheme({
 const ThemeProvider = ({ children, colorScheme }: { children: ReactNode; colorScheme?: "light" | "dark" }) => {
   useEffect(() => {
     colorScheme === "dark"
-      ? parent.document.getElementById("storybook-preview-wrapper")?.style.setProperty("background", "#0e061c")
-      : parent.document.getElementById("storybook-preview-wrapper")?.style.setProperty("background", "#fff");
-  }, []);
+      ? document.body?.style.setProperty("background", "#0e061c")
+      : document.body?.style.setProperty("background", "fff");
+  }, [colorScheme]);
   return <MuiThemeProvider theme={colorScheme === "dark" ? darkTheme : theme} children={children} />;
 };
 

--- a/src/design-system/theme/index.tsx
+++ b/src/design-system/theme/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 
 import { ThemeProvider as MuiThemeProvider, createTheme } from "@mui/material/styles";
 
@@ -23,6 +23,11 @@ export const darkTheme = createTheme({
 });
 
 const ThemeProvider = ({ children, colorScheme }: { children: ReactNode; colorScheme?: "light" | "dark" }) => {
+  useEffect(() => {
+    colorScheme === "dark"
+      ? parent.document.getElementById("storybook-preview-wrapper")?.style.setProperty("background", "#0e061c")
+      : parent.document.getElementById("storybook-preview-wrapper")?.style.setProperty("background", "#fff");
+  }, []);
   return <MuiThemeProvider theme={colorScheme === "dark" ? darkTheme : theme} children={children} />;
 };
 


### PR DESCRIPTION
# What does this PR do?

![Kapture 2023-03-28 at 10 51 00](https://user-images.githubusercontent.com/215949/228280727-4bb09c29-3a08-4664-82ed-277e09b615f6.gif)

Adds an animated outlined button variant with optional animated SVG paths, including dark and light modes, clean up dark mode form styles, update button border radius with new prop for pill style buttons.

Updated form styles for dark mode:

<img width="230" alt="Screen+Shot+2023-03-29+at+8 30 47+AM" src="https://user-images.githubusercontent.com/215949/228536046-04ced03d-546f-4d34-abb5-c4cea152fe72.png">

Updated default button radius:

<img width="127" alt="Screen+Shot+2023-03-29+at+10 12 20+AM" src="https://user-images.githubusercontent.com/215949/228566863-d2199141-c561-464e-9293-bcdd6aa9ecaa.png">


* add conic gradient outlined button styles
* update storybook iframe background color based on dark/light theme for demo purposes
* add scripting for svg icons to get path length for equalized animation timings
* add svg path animations
* adjust for dark/light variants
* cleans up grey buttons for dark mode
* update border radius to use newly accepted 8px value, add prop for 'pill' style buttons

## Limitations

N/A

## Test Plan

Manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
