### PR TITLE
feature(ui): dark mode cleanup & palette updates

### DIFF
--- a/src/design-system/components/dialog/Dialog.tsx
+++ b/src/design-system/components/dialog/Dialog.tsx
@@ -20,6 +20,20 @@ const Dialog = ({ PaperProps, ...props }: DialogProps) => {
         "color": theme.palette.text.primary,
         ".MuiFormControl-root p, .MuiButton-containedGrey": { color: theme.palette.text.primary },
         "svg[data-testid='CloseIcon']:hover": { color: theme.palette.primary[50] },
+        "*:hover::-webkit-scrollbar-thumb": {
+          background: isDark ? theme.palette.primary[60] : theme.palette.primary[30],
+        },
+        "*:hover::-webkit-scrollbar-track": {
+          background: isDark ? theme.palette.common.black : theme.palette.primary[10],
+        },
+        "*::-webkit-scrollbar-thumb, *::-webkit-scrollbar-track": {
+          background: "transparent",
+          borderRadius: "8px",
+        },
+        "*::-webkit-scrollbar": {
+          width: "4px",
+          height: "4px",
+        },
         ...(isDark && {
           ".MuiOutlinedInput-root:not(.body2)": {
             background: theme.palette.grey["20"],
@@ -27,12 +41,6 @@ const Dialog = ({ PaperProps, ...props }: DialogProps) => {
           ".MuiButton-containedGrey": {
             "color": theme.palette.common.black,
             "&:hover": { color: theme.palette.common.white },
-          },
-          "*:hover::-webkit-scrollbar-thumb": {
-            background: theme.palette.primary[60],
-          },
-          "*:hover::-webkit-scrollbar-track": {
-            background: theme.palette.common.black,
           },
         }),
       }}

--- a/src/design-system/components/select/index.tsx
+++ b/src/design-system/components/select/index.tsx
@@ -201,7 +201,7 @@ const Select = React.forwardRef(
               paddingLeft: "8px",
             },
             "& .MuiInputBase-adornedStart > .MuiSvgIcon-root:first-of-type": {
-              color: "#050505",
+              color: (theme: any) => theme.palette.grey[100],
               paddingRight: "8px",
               paddingLeft: "12px",
               left: "0px",

--- a/src/design-system/theme/components/pagination.ts
+++ b/src/design-system/theme/components/pagination.ts
@@ -19,7 +19,7 @@ const pagination: any = {
           },
           "&.Mui-selected": {
             color: theme.palette.primary.main,
-            backgroundColor: theme.palette.primary["10"],
+            backgroundColor: theme.palette.primary["5"],
           },
           "&.Mui-selected:hover": {
             color: theme.palette.primary.main,

--- a/src/design-system/theme/components/tabs.ts
+++ b/src/design-system/theme/components/tabs.ts
@@ -15,11 +15,13 @@ const tabs: any = {
         return {
           "textTransform": "none",
           "fontSize": "14px",
-          "&.Mui-selected": {
+          "&.MuiTab-root.Mui-selected": {
             border: ownerState.variant === "outlined" && "1px solid",
             borderRadius: "6px 6px 0 0",
             borderColor: theme.palette.divider,
-            backgroundColor: ownerState.variant === "outlined" && "white",
+            backgroundColor: ownerState.variant === "outlined" ? "white" : theme.palette.primary[5],
+            color: theme.palette.primary[50],
+            background: ownerState.variant === "outlined" ? "white" : theme.palette.primary[5],
           },
         };
       },

--- a/src/design-system/theme/paletteDark.ts
+++ b/src/design-system/theme/paletteDark.ts
@@ -14,6 +14,7 @@ const primary: PaletteColorOptions & Record<string, any> = {
   "80": "#D0B6F6",
   "90": "#EEE4FC",
   "100": "#F7F1FD",
+  "oppositeMainText": "#1C1C1C",
   "contrastText": "#FFFFFF",
   "gradient": "linear-gradient(205deg, #BB8BFF 8.49%, #75F6FF 91.51%)",
 };
@@ -95,6 +96,7 @@ const grey: ColorPartial & Record<string, string> = {
   "80": "#B5B5B5",
   "90": "#CFCFCF",
   "100": "#E8E8E8",
+  "oppositeBackground": "#FFF",
   "contrastText": "#1C1C1C",
 };
 const background: Partial<TypeBackground> = {


### PR DESCRIPTION
# What does this PR do?

Modal scrollbars:
<img width="515" alt="Screenshot+2023-04-06+at+4 07 41+PM" src="https://user-images.githubusercontent.com/215949/230484690-6080328e-4790-4279-92e3-d39ab34342f0.png">
<img width="507" alt="Screenshot+2023-04-06+at+4 06 49+PM" src="https://user-images.githubusercontent.com/215949/230484704-32786ecf-8f59-4f20-afd0-decc3d74671e.png">

Dark mode tabs:
<img width="509" alt="Screenshot+2023-04-06+at+4 07 59+PM" src="https://user-images.githubusercontent.com/215949/230484777-1535137e-ae67-47e4-bf22-5be644fae2fe.png">


* update tooltip backgrounds for offset/contrast, remove opacity
* update pagination for consistency with platform patterns
* update tabs for consistency with platform patterns
* add scrollbar styles for dialog/modal components
* add contrast background to dark palette

## Limitations

N/A

## Test Plan

Manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
