### PR TITLE
fix(ui): revert font size updates

### DIFF
--- a/src/design-system/theme/typography.ts
+++ b/src/design-system/theme/typography.ts
@@ -52,13 +52,13 @@ const typography: TypographyOptions = {
   },
   body1: {
     fontWeight: 400,
-    fontSize: "14px",
+    fontSize: "16px",
     letterSpacing: "-0.015em",
     lineHeight: "normal",
   },
   body2: {
     fontWeight: 400,
-    fontSize: "12px",
+    fontSize: "14px",
     letterSpacing: "-0.01em",
   },
   caption: {


### PR DESCRIPTION
# What does this PR do?

Revert Chris' body font size updates
from:
<img width="96" alt="Screenshot+2023-04-10+at+11 42 49+AM" src="https://user-images.githubusercontent.com/215949/230937405-667cc515-ec64-4b9f-af9d-387ae3671727.png">

to:
<img width="92" alt="Screenshot+2023-04-10+at+11 41 53+AM" src="https://user-images.githubusercontent.com/215949/230937434-a20e55e8-84c1-4957-87e0-cd866c55fddb.png">


## Limitations

n/a

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
