### PR TITLE
fix(ui): allow enabling interactive tooltips

### DIFF
--- a/src/design-system/components/tooltip/index.tsx
+++ b/src/design-system/components/tooltip/index.tsx
@@ -15,7 +15,7 @@ const Tooltip = ({
   children,
   placement = "top",
   width,
-  interactive = true,
+  interactive = false,
   delay = 500,
   enterNextDelay = 400,
 }: TooltipProps) => {
@@ -23,7 +23,7 @@ const Tooltip = ({
     <MuiTooltip
       title={title}
       placement={placement}
-      disableInteractive={interactive}
+      disableInteractive={!interactive}
       enterDelay={delay}
       enterNextDelay={enterNextDelay}>
       <Box component={"span"} sx={{ cursor: title ? "pointer" : "inherit", width }}>


### PR DESCRIPTION
# What does this PR do?

This PR allows enabling interactive tooltips by passing `interactive: true`. The interactive is still disabled by default, as it was before.

## Limitations

N/A

## Test Plan

Manual validation.

## Submit checklist

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
