### PR TITLE
fix(ui): lighten secondary text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ""
+title: ''
 labels: bug, help wanted
-assignees: ""
+assignees: ''
 ---
 
 ## 🐛 Bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ""
+title: ''
 labels: enhancement, help wanted
-assignees: ""
+assignees: ''
 ---
 
 ## 🚀 Feature

--- a/src/design-system/theme/palette.ts
+++ b/src/design-system/theme/palette.ts
@@ -136,7 +136,7 @@ const background: Partial<TypeBackground> = {
 
 const text: Partial<TypeText> = {
   primary: "#1C1C1C",
-  secondary: "#212529",
+  secondary: "#696969",
   disabled: "#828282",
 };
 

--- a/src/design-system/theme/paletteDark.ts
+++ b/src/design-system/theme/paletteDark.ts
@@ -133,7 +133,7 @@ const background: Partial<TypeBackground> = {
 
 const text: Partial<TypeText> = {
   primary: "#FAFAFA",
-  secondary: "#4F4F4F",
+  secondary: "#B5B5B5",
   disabled: "#828282",
 };
 

--- a/src/design-system/theme/paletteDark.ts
+++ b/src/design-system/theme/paletteDark.ts
@@ -133,7 +133,7 @@ const background: Partial<TypeBackground> = {
 
 const text: Partial<TypeText> = {
   primary: "#FAFAFA",
-  secondary: "#CFCFCF",
+  secondary: "#4F4F4F",
   disabled: "#828282",
 };
 


### PR DESCRIPTION
# What does this PR do?

Lightens secondary text color for better distinction vs primary.

## Limitations

n/a

## Test Plan

n/a

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
