### PR TITLE
feat(ui): allow title-less dialog titles

### DIFF
--- a/src/design-system/components/dialog/DialogTitle.tsx
+++ b/src/design-system/components/dialog/DialogTitle.tsx
@@ -4,7 +4,7 @@ import { IconButton, Stack, Typography } from "..";
 import { Close } from "../../icons";
 
 export type DialogTitleProps = {
-  text: string;
+  text?: string;
   subtext?: string;
   onCloseClick?: () => void;
   center?: boolean;
@@ -13,7 +13,11 @@ export type DialogTitleProps = {
 const DialogTitle = ({ text, subtext, onCloseClick, center }: DialogTitleProps) => (
   <MuiDialogTitle>
     <Stack spacing={0.75} alignItems={center ? "center" : undefined}>
-      <Stack direction={"row"} justifyContent={center ? "center" : "flex-start"} alignItems={"center"}>
+      <Stack
+        minHeight={"20px"}
+        direction={"row"}
+        justifyContent={center ? "center" : "flex-start"}
+        alignItems={"center"}>
         <Typography
           sx={{
             marginX: center ? "20px" : undefined,


### PR DESCRIPTION
# What does this PR do?

This PR allows titles dialog titles and makes sure that the x icon isn't being misplaced when there is no title.

<img width="669" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/c93004d6-3611-4a46-9dd5-d44ee92923b6">

<img width="670" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/99a5b367-1ba1-46c8-8c83-eff620b39a1d">

## Limitations

N/A

## Test Plan

Manual validation.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
