### PR TITLE
feat(ui): add sticky prop for sticky table headers

### DIFF
--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -37,7 +37,6 @@ const Table = (props: TableProps) => {
   return (
     <MuiTableContainer>
       <Box
-        position={"relative"}
         sx={{
           [`& .MuiTableRow-root:hover .${TableRowContentShowOnHoverClass}`]: {
             opacity: 1,
@@ -72,6 +71,7 @@ const Table = (props: TableProps) => {
             overflow: "auto",
             height: "100%",
             maxHeight: "100%",
+            position: "relative",
           }),
         }}>
         <MuiTable>

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -6,6 +6,7 @@ import MuiTableCell from "@mui/material/TableCell";
 import MuiTableContainer from "@mui/material/TableContainer";
 import MuiTableHead from "@mui/material/TableHead";
 import MuiTableRow from "@mui/material/TableRow";
+import { useTheme } from "@mui/material/styles";
 
 import { Box, BoxProps } from "..";
 import TableRow from "./TableRow";
@@ -27,13 +28,16 @@ export type TableProps = {
   rowHover?: boolean;
   rowClick?: any;
   border?: boolean;
+  sticky?: boolean;
   sx?: BoxProps["sx"];
 };
 
 const Table = (props: TableProps) => {
+  const theme: any = useTheme();
   return (
     <MuiTableContainer>
       <Box
+        position={"relative"}
         sx={{
           [`& .MuiTableRow-root:hover .${TableRowContentShowOnHoverClass}`]: {
             opacity: 1,
@@ -53,6 +57,22 @@ const Table = (props: TableProps) => {
               }
             : {}),
           ...props.sx,
+          ...(props.sticky && {
+            th: {
+              position: "sticky",
+              top: "0",
+              zIndex: 2,
+              background: theme.palette.background.default,
+            },
+            tbody: {
+              overflow: "auto",
+              height: "100%",
+              maxHeight: "100%",
+            },
+            overflow: "auto",
+            height: "100%",
+            maxHeight: "100%",
+          }),
         }}>
         <MuiTable>
           <MuiTableHead>

--- a/src/design-system/components/table/table.stories.tsx
+++ b/src/design-system/components/table/table.stories.tsx
@@ -27,8 +27,8 @@ const Template: ComponentStory<typeof Table> = ({ header, rowDetails, border }: 
     "AWS",
     "Not yet run",
   ];
-  const rows = [rowCell, rowCell, rowCell];
-  return <Table header={header} rows={rows} rowDetails={rowDetails} border={border} />;
+  const rows = [rowCell, rowCell, rowCell, rowCell, rowCell, rowCell];
+  return <Table header={header} rows={rows} rowDetails={rowDetails} border={border} sticky />;
 };
 
 export const WithHeader = Template.bind({});


### PR DESCRIPTION
# What does this PR do?

![Kapture 2023-07-07 at 11 44 38](https://github.com/Lightning-AI/lightning-ui/assets/215949/fad29919-4c6e-48f1-aedb-675214ae5e97)

Adds a prop to the `<Table>` component for sticky headers.

## Limitations

In order for `position: sticky` to function properly an explicit height must be set for the parent container (`height: 100%` is acceptable and applied to the wrapping `<Box>` component to assist here).

## Test Plan

n/a

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
