### PR TITLE
fix: turn off text field autocomplete by default

### DIFF
--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -37,7 +37,7 @@ export type TextFieldProps = {
 } & FormControlProps &
   Pick<
     MuiOutlinedInputProps,
-    "disabled" | "placeholder" | "fullWidth" | "size" | "autoComplete" | "autoCapitalize" | "autoCorrect" | "autoFocus"
+    "disabled" | "placeholder" | "fullWidth" | "size" | "autoComplete" | "aria-autocomplete" | "autoCapitalize" | "autoCorrect" | "autoFocus"
   >;
 
 const INPUT_TEXT_FONT = `normal 14px/20px "Inter"`;
@@ -62,6 +62,10 @@ const TextField = React.forwardRef(
       max,
       min,
       loading,
+      // "nope" is better at disabling autocomplete, than "off"
+      // because most modern browsers ignore "off" https://stackoverflow.com/a/38961567
+      autoComplete = "nope",
+      "aria-autocomplete": ariaAutocomplete = "none",
       ...props
     }: TextFieldProps,
     ref: any,
@@ -128,6 +132,8 @@ const TextField = React.forwardRef(
             fullWidth={fullWidth}
             onChange={onChangeHandler}
             type={type}
+            autoComplete={autoComplete}
+            aria-autocomplete={ariaAutocomplete}
             {...props}
             inputProps={{
               max: max !== undefined ? Math.min(max, MAX_NUMBER) : MAX_NUMBER,


### PR DESCRIPTION
# What does this PR do?

This PR turns off TextField autocomplete by default.

## Limitations

N/A

## Test Plan

Manual validation.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
