### PR TITLE
feat(TextField): disable autocomplete in dashlane and lastpass if `autocomplete` is `off` or `nope`

### DIFF
--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -143,13 +143,15 @@ const TextField = React.forwardRef(
             autoComplete={autoComplete}
             {...props}
             inputProps={{
-              max: max !== undefined ? Math.min(max, MAX_NUMBER) : MAX_NUMBER,
-              min: min !== undefined ? Math.max(min, -MAX_NUMBER) : -MAX_NUMBER,
+              "max": max !== undefined ? Math.min(max, MAX_NUMBER) : MAX_NUMBER,
+              "min": min !== undefined ? Math.max(min, -MAX_NUMBER) : -MAX_NUMBER,
               "aria-autocomplete": ariaAutocomplete,
-              ...(autoComplete === "nope" || autoComplete === "off" ? {
-                "data-form-type": "other",
-                "data-lpignore": "true",
-              } : {}),
+              ...(autoComplete === "nope" || autoComplete === "off"
+                ? {
+                    "data-form-type": "other",
+                    "data-lpignore": "true",
+                  }
+                : {}),
             }}
             error={hasStatus}
             startAdornment={icon}

--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -141,11 +141,15 @@ const TextField = React.forwardRef(
             onChange={onChangeHandler}
             type={type}
             autoComplete={autoComplete}
-            aria-autocomplete={ariaAutocomplete}
             {...props}
             inputProps={{
               max: max !== undefined ? Math.min(max, MAX_NUMBER) : MAX_NUMBER,
               min: min !== undefined ? Math.max(min, -MAX_NUMBER) : -MAX_NUMBER,
+              "aria-autocomplete": ariaAutocomplete,
+              ...(autoComplete === "nope" || autoComplete === "off" ? {
+                "data-form-type": "other",
+                "data-lpignore": "true",
+              } : {}),
             }}
             error={hasStatus}
             startAdornment={icon}


### PR DESCRIPTION
# What does this PR do?

This PR disables autocomplete in dashlane and LastPass if `autoComplete=off` or `autoComplete=nope`.

## Limitations

N/A

## Test Plan

Manual validation.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
