### PR TITLE
fix(TextField): force-hide LastPass autocomplete

### DIFF
--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -130,6 +130,8 @@ const TextField = React.forwardRef(
       }
     };
 
+    const isAutocompleteDisabled = autoComplete === "nope" || autoComplete === "off";
+
     return (
       <FormControl
         label={label}
@@ -156,7 +158,7 @@ const TextField = React.forwardRef(
               "max": max !== undefined ? Math.min(max, MAX_NUMBER) : MAX_NUMBER,
               "min": min !== undefined ? Math.max(min, -MAX_NUMBER) : -MAX_NUMBER,
               "aria-autocomplete": ariaAutocomplete,
-              ...(autoComplete === "nope" || autoComplete === "off" ? TURN_OFF_AUTOCOMPLETE_INPUT_PROPS : undefined),
+              ...(isAutocompleteDisabled ? TURN_OFF_AUTOCOMPLETE_INPUT_PROPS : undefined),
             }}
             error={hasStatus}
             startAdornment={icon}
@@ -171,6 +173,12 @@ const TextField = React.forwardRef(
               "input": {
                 marginRight: `${marginRightPx}px`,
               },
+              ...(isAutocompleteDisabled && {
+                // LastPass doesn't always respect `data-lpignore="true"` on the input
+                "[data-lastpass-icon-root]": {
+                  display: "none !important",
+                },
+              }),
               ...(isDark && {
                 ".MuiOutlinedInput-notchedOutline": {
                   borderColor: theme.palette.grey["50"],


### PR DESCRIPTION
# What does this PR do?

Force-hide LastPass autocomplete when it's off because it doesn't always respect `data-lpignore`.

## Limitations

N/A

## Test Plan

Manual validation.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
