### PR TITLE
remove stepper arrows from number field by default

### DIFF
--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -41,6 +41,7 @@ export type TextFieldProps = {
   onChange: (value: string | null) => void;
   value?: unknown;
   suffix?: string;
+  arrows?: boolean;
   max?: number;
   min?: number;
   loading?: boolean;
@@ -74,6 +75,7 @@ const TextField = React.forwardRef(
       fullWidth,
       optional,
       tooltip,
+      arrows,
       onChange,
       type = "text",
       suffix,
@@ -169,7 +171,7 @@ const TextField = React.forwardRef(
               "font": INPUT_TEXT_FONT,
               "height": "36px",
               "backgroundColor": isDark ? theme.palette.grey["10"] : theme.palette.background.default,
-              "borderRadius": type === "number" ? "8px 0 0 8px" : "8px",
+              "borderRadius": type === "number" && arrows ? "8px 0 0 8px" : "8px",
               "input": {
                 marginRight: `${marginRightPx}px`,
               },
@@ -227,7 +229,7 @@ const TextField = React.forwardRef(
               },
             }}
           />
-          {type === "number" && (
+          {type === "number" && arrows && (
             <NumberInputButtons
               onIncreaseClick={() => {
                 internalRef.current?.stepUp();

--- a/src/design-system/components/text-field/text-field.stories.tsx
+++ b/src/design-system/components/text-field/text-field.stories.tsx
@@ -81,6 +81,10 @@ export default {
       options: ["text", "number", "password"],
       control: "select",
     },
+    arrows: {
+      defaultValue: false,
+      control: "boolean",
+    },
     onChange: { action: "changed" },
   },
 } as ComponentMeta<typeof TextField>;


### PR DESCRIPTION


# What does this PR do?

![Kapture 2023-08-18 at 15 41 30](https://github.com/Lightning-AI/lightning-ui/assets/215949/bcf6e01f-d64a-4d50-8b24-3aad6f9e1c6e)

* remove stepper arrows as default
* add prop to include them
* adjust styling accordingly

## Limitations

n/a

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
