### PR TITLE
fix(ui): table header overflow, toast background

### DIFF
--- a/src/design-system/components/alert/index.tsx
+++ b/src/design-system/components/alert/index.tsx
@@ -57,7 +57,7 @@ const Alert = ({ children, show, ...props }: AlertProps) => {
         "fontSize": "14px",
         "lineHeight": "20px",
         "borderLeft": `8px solid ${severityColor[props.severity ?? "info"]}`,
-        "backgroundColor": "white",
+        "backgroundColor": "white !important" as any,
         "padding": "12px",
         "width": "500px",
         "wordBreak": "break-all",

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -68,7 +68,7 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
             transition: "0.2s ease-in-out",
           },
           ".MuiTableCell-root": { overflow: "hidden", textOverflow: "ellipsis" },
-          "th.MuiTableCell-head": { overflow: "visible" },
+          "th.MuiTableCell-head, .MuiTableCell-head": { overflow: "visible" },
           ...(props.border
             ? {
                 padding: "24px",

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -68,6 +68,7 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
             transition: "0.2s ease-in-out",
           },
           ".MuiTableCell-root": { overflow: "hidden", textOverflow: "ellipsis" },
+          "th.MuiTableCell-head": { overflow: "visible" },
           ...(props.border
             ? {
                 padding: "24px",


### PR DESCRIPTION


# What does this PR do?

Before:
<img src="https://camo.githubusercontent.com/1e3dd0edd33d5187c1de96537eda51aa9d8a7d8bf5ad6967e10961d41dde85c4/68747470733a2f2f7075752e73682f4a4f4b50422f396631396437383736622e706e67">

After:
<img src="https://camo.githubusercontent.com/e28844d2121e7bfc17559bd8b9194f4623f4c76d74f83bb65682d4d8d8bd38c7/68747470733a2f2f7075752e73682f4a4f4b50762f663565623466333935372e706e67">

* update table headers to allow overflow in order to maintain popover/tooltip visibility
* update toast background to strictly enforce due to user-identified transparent background (https://puu.sh/JOOmw/ee8ba91a80.png)

## Limitations

n/a

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
