### PR TITLE
fix(ui): update dark mode selection colors

### DIFF
--- a/src/design-system/components/dialog/Dialog.tsx
+++ b/src/design-system/components/dialog/Dialog.tsx
@@ -34,6 +34,10 @@ const Dialog = ({ PaperProps, ...props }: DialogProps) => {
           width: "4px",
           height: "4px",
         },
+
+        "*::selection": {
+          background: isDark ? theme.palette.primary[30] : theme.palette.primary[80],
+        },
         ...(isDark && {
           ".MuiOutlinedInput-root:not(.body2)": {
             background: theme.palette.grey["20"],


### PR DESCRIPTION
# What does this PR do?

Update text selection colors in modals for dark mode.

Before:
<img src="https://puu.sh/JOOCi/6584d4ff8c.png">

After:
<img src="https://puu.sh/JOOC5/e662b168fa.png">

## Limitations

none

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
