### PR TITLE
fix(ui): remove ::selection styles from dialog

### DIFF
--- a/src/design-system/components/dialog/Dialog.tsx
+++ b/src/design-system/components/dialog/Dialog.tsx
@@ -34,10 +34,6 @@ const Dialog = ({ PaperProps, ...props }: DialogProps) => {
           width: "4px",
           height: "4px",
         },
-
-        "*::selection": {
-          background: isDark ? theme.palette.primary[30] : theme.palette.primary[80],
-        },
         ...(isDark && {
           ".MuiOutlinedInput-root:not(.body2)": {
             background: theme.palette.grey["20"],

--- a/src/design-system/theme/index.tsx
+++ b/src/design-system/theme/index.tsx
@@ -35,7 +35,7 @@ const ThemeProvider = ({ children, colorScheme }: { children: ReactNode; colorSc
       <GlobalStyles
         styles={{
           "*::selection": {
-            background: theme.palette.primary[20],
+            background: colorScheme === "dark" ? darkTheme.palette.primary[20] : theme.palette.primary[20],
           },
         }}
       />


### PR DESCRIPTION


# What does this PR do?
Removes selection styles from dialog component in favor of globals.

Light:
<img src="https://puu.sh/JOU5h/8bde458f7b.png">

Dark:
<img src="https://puu.sh/JOU5o/f26e945d2d.png">

* remove selection styles from dialog component
* add dark theme variant

## Limitations

n/a

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
