### PR TITLE
fix(ui: dark mode toast highlight

### DIFF
--- a/src/design-system/components/alert/alert.stories.tsx
+++ b/src/design-system/components/alert/alert.stories.tsx
@@ -24,7 +24,7 @@ export default {
       control: "select",
     },
     children: {
-      defaultValue: "You are offline, Please check your connectiviy",
+      defaultValue: "You are offline, Please check your connectivity",
       control: "text",
     },
     show: {

--- a/src/design-system/theme/index.tsx
+++ b/src/design-system/theme/index.tsx
@@ -37,6 +37,9 @@ const ThemeProvider = ({ children, colorScheme }: { children: ReactNode; colorSc
           "*::selection": {
             background: colorScheme === "dark" ? darkTheme.palette.primary[20] : theme.palette.primary[20],
           },
+          ".MuiAlert-root *::selection": {
+            background: colorScheme === "dark" ? "#EEE4FC" : "#EEE4FC",
+          },
         }}
       />
       {children}


### PR DESCRIPTION
# What does this PR do?

Fixes contrast issues with text hovers on dark mode toasts.

Before:
<img src="https://puu.sh/JPD2W/a67dd414e8.png">

After:
<img src="https://puu.sh/JPD2J/61dcedffb6.png">

* update global styles for toast text highlight

## Limitations

n/a

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
