### PR TITLE
feat(ui): add grouped variant for tabs component

### DIFF
--- a/src/design-system/components/tabs/index.tsx
+++ b/src/design-system/components/tabs/index.tsx
@@ -2,6 +2,7 @@ import { MouseEventHandler, ReactNode, useEffect, useState } from "react";
 
 import { TabContext } from "@mui/lab";
 import { BoxProps, Tab as MuiTab, TabProps as MuiTabProps, Tabs as MuiTabs } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { Tooltip } from "..";
@@ -28,7 +29,7 @@ export type TabItem = (StaticTabItem | NavigableTabItem) & TabItemMetadata;
 export type TabsProps = {
   selectedTab?: number;
   tabItems: TabItem[];
-  variant?: "text" | "outlined";
+  variant?: "text" | "outlined" | "grouped";
   /**
    * @default true
    */
@@ -69,6 +70,8 @@ const Tabs = ({
 
   const hasContent = tabItems.some(tabItem => typeof tabItem.content !== "undefined");
   const pathIndex = tabItems.findIndex(tabItem => "path" in tabItem && tabItem.path === location.pathname);
+  const theme: any = useTheme();
+  const isDark = theme.palette.mode === "dark";
 
   useEffect(() => {
     const newSelectedTab = pathIndex !== -1 ? pathIndex : tabItems.findIndex(tabItem => !tabItem.disabled);
@@ -121,6 +124,32 @@ const Tabs = ({
                   overflow: "hidden",
                   userSelect: "none",
                 },
+                ...(variant === "grouped" && {
+                  "fontSize": "12px",
+                  "background": isDark ? "#262626" : "#f9fafb",
+                  "position": "relative",
+                  "zIndex": "1",
+                  "margin": "0 -12px 0 0",
+                  "padding": "4px 16px",
+                  "height": "auto",
+                  "minHeight": "0px",
+                  "&.Mui-selected": {
+                    zIndex: "9",
+                    boxShadow: isDark ? "0 1px 1.5px 0.25px rgba(0,0,0,0.5)" : "0 1px 1.5px 0.5px rgba(0,0,0,0.175)",
+                    background: isDark ? "#363636" : (`${theme.palette.common.white} !important` as any),
+                    color: isDark
+                      ? (`${theme.palette.common.white} !important` as any)
+                      : (`${theme.palette.common.black} !important` as any),
+                  },
+                  "&:hover": {
+                    color: isDark
+                      ? (`${theme.palette.common.white} !important` as any)
+                      : (`${theme.palette.common.black} !important` as any),
+                  },
+                  ...(isDark && {
+                    color: "#828282",
+                  }),
+                }),
               }}
               onClick={"path" in tabItem && navigateHandler(tabItem.path, index)}
             />

--- a/src/design-system/components/tabs/tabs.stories.tsx
+++ b/src/design-system/components/tabs/tabs.stories.tsx
@@ -12,7 +12,7 @@ export default {
   },
   argTypes: {
     variant: {
-      options: ["text", "outlined"],
+      options: ["text", "outlined", "grouped"],
       control: "select",
     },
     divider: {


### PR DESCRIPTION


# What does this PR do?

Light:
<img src="https://puu.sh/JQCje/3fdf008123.png">

Dark:
<img src="https://puu.sh/JQCj6/dcd03406e0.png">

* add `variant={"grouped"}` prop based on `<JointTabs>` component in UI
* add alternate styles for dark mode
* update margins & padding for button group appearance

## Limitations

n/a

## Test Plan

manual validation

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
