### PR TITLE
ci: bump version after publishing new version via PR

### DIFF
--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -71,7 +71,7 @@ jobs:
         id: parse
         run: |
           echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Pack UI
         working-directory: build/
         run: |

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-package:
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -31,7 +31,7 @@ jobs:
           path: build/
 
   upload-package:
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-22.04"
     needs: build-package
     if: github.event_name == 'release'
     env:
@@ -56,21 +56,28 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-package:
-    runs-on: ubuntu-20.04
     needs: build-package
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: "ubuntu-22.04"
+    outputs:
+      ui-version: ${{ steps.parse.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: build-${{ github.sha }}
           path: build/
-      - run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: parse version
+        id: parse
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Pack UI
         working-directory: build/
         run: |
           echo "$VERSION" > version.info
           tar -czvf ../${VERSION}.tar.gz *
+          ls -lh .
 
       - name: Upload build to S3
         env:
@@ -79,5 +86,44 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
         run: |
           pip install -q awscli
-          ls -lh .
           aws s3 cp ${VERSION}.tar.gz s3://lightning-packages/ui/ --acl public-read
+
+  bump-UI:
+    runs-on: "ubuntu-22.04"
+    needs: publish-package
+    env:
+      TAG: ${{ needs.publish-package.outputs.ui-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: Lightning-AI/lightning
+          token: ${{ secrets.PAT_GHOST }}
+      - name: Update UI version
+        working-directory: src/
+        run: echo "${TAG}" > app-ui-version.info
+
+      - name: Create Pull Request
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "Bump UI ver `${{ env.TAG }}`"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          token: ${{ secrets.PAT_GHOST }}
+          commit-message: "bumping UI version -> (${{ env.TAG }})"
+          branch: "bump/ui-${{ env.TAG }}"
+          # Delete the branch when closing pull requests, and when undeleted after merging.
+          delete-branch: true
+          # the PR"s body/content
+          body: >
+            **This is automated update with the latest UI
+              [release](https://github.com/Lightning-AI/lightning-ui/releases/tag/${{ env.TAG }})!**
+
+            Please, proceed with this update in timely manner...
+          assignees: |
+            yurijmikhalevich
+            borda
+          reviewers: |
+            justusschock
+            ethanwharris
+            borda

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ frontend code, simply run `yarn build` again, and refresh the browser window to 
 The `lightning-ui` release process is automated with GitHub actions and is published to
 [S3 bucket](s3:/lightning-packages/ui/) or as an artifact to eventual GitHub release.
 
-Note that the automation assumes the new release shall have an incremented version, such as `v0.0.n`. To be used in
-[lightning](https://github.com/Lightning-AI/lightning) you also need to update version in
-[`src/app-ui-version.info`](https://github.com/Lightning-AI/lightning/blob/master/src/app-ui-version.info).
+Note that the automation assumes the new release shall have an incremented version, such as `v0.0.n`. 
+With creating a tag and uploading to S3 it will also create PR with bumpit this version in [lightning](https://github.com/Lightning-AI/lightning) repository.
+
+In case such PR is not created, you need to update version in [`src/app-ui-version.info`](https://github.com/Lightning-AI/lightning/blob/master/src/app-ui-version.info).
 
 ### Automated releasing
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ frontend code, simply run `yarn build` again, and refresh the browser window to 
 The `lightning-ui` release process is automated with GitHub actions and is published to
 [S3 bucket](s3:/lightning-packages/ui/) or as an artifact to eventual GitHub release.
 
-Note that the automation assumes the new release shall have an incremented version, such as `v0.0.n`. 
-With creating a tag and uploading to S3 it will also create PR with bumpit this version in [lightning](https://github.com/Lightning-AI/lightning) repository.
+Note that the automation assumes the new release shall have an incremented version, such as `v0.0.n`. With creating a
+tag and uploading to S3 it will also create PR with bumpit this version in
+[lightning](https://github.com/Lightning-AI/lightning) repository.
 
-In case such PR is not created, you need to update version in [`src/app-ui-version.info`](https://github.com/Lightning-AI/lightning/blob/master/src/app-ui-version.info).
+In case such PR is not created, you need to update version in
+[`src/app-ui-version.info`](https://github.com/Lightning-AI/lightning/blob/master/src/app-ui-version.info).
 
 ### Automated releasing
 


### PR DESCRIPTION
# What does this PR do?

automate updating UI version in lightning repo when new version is released

## Limitations

none

## Test Plan

<!--
Write any specific testing instructions for the reviewers.
-->

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [ ] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
