### PR TITLE
Added inconsolata explicitly

### DIFF
--- a/src/design-system/style.css
+++ b/src/design-system/style.css
@@ -2,3 +2,4 @@
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata&display=swap');

--- a/src/design-system/style.css
+++ b/src/design-system/style.css
@@ -1,5 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Mono&display=swap");
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Inter:wght@300;400;500;600;700&display=swap');
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata&display=swap');

--- a/src/design-system/style.css
+++ b/src/design-system/style.css
@@ -1,5 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Mono&display=swap");
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
-@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Inter:wght@300;400;500;600;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inconsolata&family=Inter:wght@300;400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Inconsolata&display=swap");


### PR DESCRIPTION
# What does this PR do?

It adds `inconsolata` explicitly to the font stack used in `style.css`; it doesn't appear to be imported in the grid repository and thus may not work under certain circumstances, such as being called in the `FontWrapper` component.

## Test Plan

Once merged, it'd be ideal to test the import in the `FontWrapper` component, which in turn would allow us to switch from `Roboto Mono` in Studio terminals to `inconsolata`.