### PR TITLE
Fix(ci): Adding data test id to DialogTitle

### DIFF
--- a/src/design-system/components/dialog/DialogTitle.tsx
+++ b/src/design-system/components/dialog/DialogTitle.tsx
@@ -7,11 +7,11 @@ export type DialogTitleProps = {
   text?: string;
   subtext?: string;
   onCloseClick?: () => void;
-  onCloseDataTestId?: string;
+  closeDataTestId?: string;
   center?: boolean;
 };
 
-const DialogTitle = ({ text, subtext, onCloseClick, onCloseDataTestId, center }: DialogTitleProps) => (
+const DialogTitle = ({ text, subtext, onCloseClick, closeDataTestId, center }: DialogTitleProps) => (
   <MuiDialogTitle>
     <Stack spacing={0.75} alignItems={center ? "center" : undefined}>
       <Stack
@@ -36,7 +36,7 @@ const DialogTitle = ({ text, subtext, onCloseClick, onCloseDataTestId, center }:
             disableFocusRipple
             sx={{ color: (theme: any) => theme.palette.text.primary, padding: 0, position: "absolute", right: "24px" }}
             onClick={onCloseClick}
-            data-testid={onCloseDataTestId}
+            data-testid={closeDataTestId}
           >
             <Close sx={{ fontSize: "16px" }} />
           </IconButton>

--- a/src/design-system/components/dialog/DialogTitle.tsx
+++ b/src/design-system/components/dialog/DialogTitle.tsx
@@ -36,8 +36,7 @@ const DialogTitle = ({ text, subtext, onCloseClick, closeDataTestId, center }: D
             disableFocusRipple
             sx={{ color: (theme: any) => theme.palette.text.primary, padding: 0, position: "absolute", right: "24px" }}
             onClick={onCloseClick}
-            data-testid={closeDataTestId}
-          >
+            data-testid={closeDataTestId}>
             <Close sx={{ fontSize: "16px" }} />
           </IconButton>
         )}

--- a/src/design-system/components/dialog/DialogTitle.tsx
+++ b/src/design-system/components/dialog/DialogTitle.tsx
@@ -7,10 +7,11 @@ export type DialogTitleProps = {
   text?: string;
   subtext?: string;
   onCloseClick?: () => void;
+  onCloseDataTestId?: string;
   center?: boolean;
 };
 
-const DialogTitle = ({ text, subtext, onCloseClick, center }: DialogTitleProps) => (
+const DialogTitle = ({ text, subtext, onCloseClick, onCloseDataTestId, center }: DialogTitleProps) => (
   <MuiDialogTitle>
     <Stack spacing={0.75} alignItems={center ? "center" : undefined}>
       <Stack
@@ -34,7 +35,9 @@ const DialogTitle = ({ text, subtext, onCloseClick, center }: DialogTitleProps) 
             disableRipple
             disableFocusRipple
             sx={{ color: (theme: any) => theme.palette.text.primary, padding: 0, position: "absolute", right: "24px" }}
-            onClick={onCloseClick}>
+            onClick={onCloseClick}
+            data-testid={onCloseDataTestId}
+          >
             <Close sx={{ fontSize: "16px" }} />
           </IconButton>
         )}


### PR DESCRIPTION
# What does this PR do?

Introduces a prop for developers to inject a `data-testid` into the DialogTitle.
This allows for more granular control in CI tests.

## Limitations


## Test Plan

Usage in the `distributed-4-4xt4` test.

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [X] My PR is focused - addressing only one thing at the time
- [-] I wrote new tests \[for a bug or new feature\]
- [X] I manually QAed this PR in my local environment
- [-] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
