### PR TITLE
fix(ui): allow key as input for table rows

### DIFF
--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -152,21 +152,9 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 rowHeight={virtualizedParams.rowHeightPx}
                 overscanRowCount={virtualizedParams.overscanRowCount}
                 rowRenderer={({ index, key, style }) => {
-                  <Box key={key} style={style}>
-                    <TableRow hover={!!props.rowHover} cells={"cells" in props.rows?[index] ? props.rows[index]?.cells : props.rows[index] || []} />
-                  </Box>
-
-                  // if ("cells" in props.rows?[index]) {
-                  //   return (
-                  //     <Box key={key} style={style}>
-                  //       <TableRow hover={!!props.rowHover} cells={props.rows[index]?.cells || []} />
-                  //     </Box>);
-                  // } else {
-                  //   return (
-                  //     <Box key={key} style={style}>
-                  //       <TableRow hover={!!props.rowHover} cells={props.rows[index] || []} />
-                  //     </Box>);
-                  // }
+                    return <Box key={key} style={style}>
+                      <TableRow hover={!!props.rowHover} cells={ "cells" in props.rows[index] ? props.rows[index]?.cells : props.rows[index] || []} />
+                    </Box>
                 }}
               />
             ) : (

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -59,7 +59,9 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
   if (virtualizedParams?.enabled && props.rowDetails) {
     throw new Error("rowDetails is not supported when using virtualized");
   }
-  const columnCount: number | undefined = props.header?.length ?? (props.rows[0] && "cells" in props.rows[0] ? props.rows[0]?.cells.length : props.rows[0]?.length);
+  const columnCount: number | undefined =
+    props.header?.length ??
+    (props.rows[0] && "cells" in props.rows[0] ? props.rows[0]?.cells.length : props.rows[0]?.length);
   if (virtualizedParams?.enabled && columnCount && virtualizedParams.columnWidthsPx.length !== columnCount) {
     // TODO(yurij/alec): support virtualized tables with variable column widths
     throw new Error("virtualized table should have all column widths specified");
@@ -152,9 +154,14 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 rowHeight={virtualizedParams.rowHeightPx}
                 overscanRowCount={virtualizedParams.overscanRowCount}
                 rowRenderer={({ index, key, style }) => {
-                    return <Box key={key} style={style}>
-                      <TableRow hover={!!props.rowHover} cells={ "cells" in props.rows[index] ? props.rows[index]?.cells : props.rows[index] || []} />
+                  return (
+                    <Box key={key} style={style}>
+                      <TableRow
+                        hover={!!props.rowHover}
+                        cells={"cells" in props.rows[index] ? props.rows[index]?.cells : props.rows[index] || []}
+                      />
                     </Box>
+                  );
                 }}
               />
             ) : (

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -34,7 +34,7 @@ type VirtualizedParams = {
 
 type TableRowWithKey = {
   key: string;
-  cells: ReactNode[],
+  cells: ReactNode[];
 };
 
 type TableRowNoKey = ReactNode[];
@@ -160,10 +160,18 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
             ) : (
               props.rows.map((row, index) => {
                 if ("key" in row) {
-                  return <TableRow key={row.key} hover={!!props.rowHover} cells={row.cells} details={props.rowDetails?.[index]} />
-                } 
-                else {
-                  return <TableRow key={index} hover={!!props.rowHover} cells={row} details={props.rowDetails?.[index]} /> 
+                  return (
+                    <TableRow
+                      key={row.key}
+                      hover={!!props.rowHover}
+                      cells={row.cells}
+                      details={props.rowDetails?.[index]}
+                    />
+                  );
+                } else {
+                  return (
+                    <TableRow key={index} hover={!!props.rowHover} cells={row} details={props.rowDetails?.[index]} />
+                  );
                 }
               })
             )}

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -32,9 +32,18 @@ type VirtualizedParams = {
   overscanRowCount?: number;
 };
 
+type TableRowWithKey = {
+  key: string;
+  cells: ReactNode[],
+};
+
+type TableRowNoKey = ReactNode[];
+
+type TableRows = Array<TableRowWithKey | TableRowNoKey>;
+
 export type TableProps = {
   header?: ReactNode[];
-  rows: ReactNode[][];
+  rows: TableRows;
   rowDetails?: ReactNode[];
   rowHover?: boolean;
   rowClick?: any;
@@ -149,9 +158,14 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 )}
               />
             ) : (
-              props.rows.map((row, index) => (
-                <TableRow key={index} hover={!!props.rowHover} cells={row} details={props.rowDetails?.[index]} />
-              ))
+              props.rows.map((row, index) => {
+                if ("key" in row) {
+                  return <TableRow key={row.key} hover={!!props.rowHover} cells={row.cells} details={props.rowDetails?.[index]} />
+                } 
+                else {
+                  return <TableRow key={index} hover={!!props.rowHover} cells={row} details={props.rowDetails?.[index]} /> 
+                }
+              })
             )}
           </MuiTableBody>
         </MuiTable>

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -59,7 +59,7 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
   if (virtualizedParams?.enabled && props.rowDetails) {
     throw new Error("rowDetails is not supported when using virtualized");
   }
-  const columnCount: number | undefined = props.header?.length ?? props.rows[0]?.length;
+  const columnCount: number | undefined = props.header?.length ?? (props.rows[0] && "cells" in props.rows[0] ? props.rows[0]?.cells.length : props.rows[0]?.length);
   if (virtualizedParams?.enabled && columnCount && virtualizedParams.columnWidthsPx.length !== columnCount) {
     // TODO(yurij/alec): support virtualized tables with variable column widths
     throw new Error("virtualized table should have all column widths specified");
@@ -151,11 +151,23 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 rowCount={props.rows.length}
                 rowHeight={virtualizedParams.rowHeightPx}
                 overscanRowCount={virtualizedParams.overscanRowCount}
-                rowRenderer={({ index, key, style }) => (
+                rowRenderer={({ index, key, style }) => {
                   <Box key={key} style={style}>
-                    <TableRow hover={!!props.rowHover} cells={props.rows[index] || []} />
+                    <TableRow hover={!!props.rowHover} cells={"cells" in props.rows?[index] ? props.rows[index]?.cells : props.rows[index] || []} />
                   </Box>
-                )}
+
+                  // if ("cells" in props.rows?[index]) {
+                  //   return (
+                  //     <Box key={key} style={style}>
+                  //       <TableRow hover={!!props.rowHover} cells={props.rows[index]?.cells || []} />
+                  //     </Box>);
+                  // } else {
+                  //   return (
+                  //     <Box key={key} style={style}>
+                  //       <TableRow hover={!!props.rowHover} cells={props.rows[index] || []} />
+                  //     </Box>);
+                  // }
+                }}
               />
             ) : (
               props.rows.map((row, index) => {

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -154,6 +154,7 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 rowHeight={virtualizedParams.rowHeightPx}
                 overscanRowCount={virtualizedParams.overscanRowCount}
                 rowRenderer={({ index, key, style }) => {
+<<<<<<< HEAD
                   return (
                     <Box key={key} style={style}>
                       <TableRow
@@ -162,6 +163,19 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                       />
                     </Box>
                   );
+=======
+                    const row = props.rows[index] || [];
+                    if ("cells" in row) {
+                      return <Box key={key} style={style}>
+                        <TableRow hover={!!props.rowHover} cells={ row.cells} />
+                      </Box>
+                    } else {
+                      return <Box key={key} style={style}>
+                        <TableRow hover={!!props.rowHover} cells={ row } />
+                      </Box>
+                    }
+                    
+>>>>>>> 2cc1623 (update)
                 }}
               />
             ) : (

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -154,16 +154,6 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 rowHeight={virtualizedParams.rowHeightPx}
                 overscanRowCount={virtualizedParams.overscanRowCount}
                 rowRenderer={({ index, key, style }) => {
-<<<<<<< HEAD
-                  return (
-                    <Box key={key} style={style}>
-                      <TableRow
-                        hover={!!props.rowHover}
-                        cells={"cells" in props.rows[index] ? props.rows[index]?.cells : props.rows[index] || []}
-                      />
-                    </Box>
-                  );
-=======
                     const row = props.rows[index] || [];
                     if ("cells" in row) {
                       return <Box key={key} style={style}>
@@ -175,7 +165,6 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                       </Box>
                     }
                     
->>>>>>> 2cc1623 (update)
                 }}
               />
             ) : (

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -157,7 +157,7 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                   const row = props.rows[index] || [];
                   if ("cells" in row) {
                     return (
-                      <Box key={key} style={style}>
+                      <Box key={row.key} style={style}>
                         <TableRow hover={!!props.rowHover} cells={row.cells} />
                       </Box>
                     );

--- a/src/design-system/components/table/index.tsx
+++ b/src/design-system/components/table/index.tsx
@@ -154,17 +154,20 @@ const Table = ({ virtualizedParams, ...props }: TableProps) => {
                 rowHeight={virtualizedParams.rowHeightPx}
                 overscanRowCount={virtualizedParams.overscanRowCount}
                 rowRenderer={({ index, key, style }) => {
-                    const row = props.rows[index] || [];
-                    if ("cells" in row) {
-                      return <Box key={key} style={style}>
-                        <TableRow hover={!!props.rowHover} cells={ row.cells} />
+                  const row = props.rows[index] || [];
+                  if ("cells" in row) {
+                    return (
+                      <Box key={key} style={style}>
+                        <TableRow hover={!!props.rowHover} cells={row.cells} />
                       </Box>
-                    } else {
-                      return <Box key={key} style={style}>
-                        <TableRow hover={!!props.rowHover} cells={ row } />
+                    );
+                  } else {
+                    return (
+                      <Box key={key} style={style}>
+                        <TableRow hover={!!props.rowHover} cells={row} />
                       </Box>
-                    }
-                    
+                    );
+                  }
                 }}
               />
             ) : (


### PR DESCRIPTION
# What does this PR do?
allows passing keys for table rows to prevent out of sync keys when the ordering of the row changes
<!--
Explain the purpose of PR and any helpful context. Focus on technical details not available in linked linear ticket(s).

If the PR changes the UI or UX in any way, include screenshots or screencasts, whatever is more appropriate (e.g., use
screencast for changes including animations, dropdowns, interactions; use screenshots for component design changes). If
you are following Figma designs, also include screenshots of and Figma node links to these designs.
-->

## Limitations

<!--
Fill in any limitations/negative changes this PR introduces.
-->

## Test Plan

<!--
Write any specific testing instructions for the reviewers.
-->

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [ ] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [ ] I manually QAed this PR in my local environment
- [ ] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
