### PR TITLE
fix(ui): Select dropdown shouldn't expand to the whole height when there are a lot of options

### DIFF
--- a/src/design-system/components/select/index.tsx
+++ b/src/design-system/components/select/index.tsx
@@ -255,6 +255,9 @@ const Select = React.forwardRef(
             "& .Mui-disabled.MuiInputBase-adornedEnd svg": {
               color: (theme: any) => theme.palette.grey["50"],
             },
+            ".MuiPopover-paper": {
+              maxHeight: "300px",
+            },
           }}>
           {props.options.map(option =>
             areLabelType ? (

--- a/src/design-system/components/select/select.stories.tsx
+++ b/src/design-system/components/select/select.stories.tsx
@@ -90,6 +90,13 @@ const Template: ComponentStory<typeof Select> = ({ icon, ...args }: SelectProps)
 
 export const Playground = Template.bind({});
 
+export const LongOptionList = Template.bind({});
+const longOptions = Array.from({ length: 100 }, (_, i) => ({
+  value: `value-${i}`,
+  label: `Option ${i}`,
+}));
+LongOptionList.args = { options: longOptions };
+
 export const LabelObject = Template.bind({});
 const labelObjectOptions = [
   {


### PR DESCRIPTION
# What does this PR do?

### Now

<img width="599" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/a06cded4-95af-4df1-ad68-89256c423e91">

### Before

<img width="513" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/7478d5c7-11e2-46fb-823e-45cc91ae716a">

## Limitations

N/A

## Test Plan

Validated with a 100-item `Select` in a storybook (see screenshots above).

## Submit checklist

- [x] My PR is focused - addressing only one thing at the time
- [x] I wrote new storybook example
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
