### PR TITLE
Feat(ui): Allow custom end adornment in Text Field

### DIFF
--- a/src/design-system/components/select/index.tsx
+++ b/src/design-system/components/select/index.tsx
@@ -9,6 +9,7 @@ import { CheckCircle, Dangerous, Info, Warning } from "../../icons";
 import CheckboxBase from "../checkbox/CheckboxBase";
 import FormControl from "../form-control";
 import RadioBase from "../radio/RadioBase";
+import { BoxProps } from "..";
 
 const LABEL_HEIGHT_PX = 20;
 
@@ -47,6 +48,7 @@ export type SelectProps = {
   multiSelectedItemName?: string;
   minWidthPx?: number;
   heightPx?: number;
+  sx?: BoxProps["sx"];
 } & Pick<MuiTextFieldProps, "disabled" | "fullWidth" | "size" | "value" | "autoFocus">;
 
 const Select = React.forwardRef(
@@ -68,6 +70,7 @@ const Select = React.forwardRef(
       defaultValue,
       multiSelectedItemName,
       disabled,
+      sx,
       ...props
     }: SelectProps,
     ref,
@@ -108,7 +111,8 @@ const Select = React.forwardRef(
         statusText={statusText}
         fullWidth={fullWidth}
         optional={optional}
-        tooltip={tooltip}>
+        tooltip={tooltip}
+      >
         <MuiTextField
           inputRef={ref}
           value={selectedValue}
@@ -136,49 +140,50 @@ const Select = React.forwardRef(
             },
             renderValue: areLabelType
               ? selected => {
-                  const selectedLabel = props.options.find(option => option.value === selected)?.label ?? "";
-                  if (typeof selectedLabel === "string") return selectedLabel;
-                  return (
-                    <Stack direction={"row"}>
-                      <Box
-                        sx={{
-                          "& svg.MuiSvgIcon-root:not(.MuiSelect-icon)": {
-                            fontSize: "20px",
-                            paddingTop: 0.5,
-                            color: (theme: any) => theme.palette.grey[70],
-                          },
-                        }}>
-                        {selectedLabel.icon}
-                      </Box>
-                      <Box paddingLeft={3}>
-                        <Typography
-                          fontWeight={400}
-                          fontSize={"14px"}
-                          lineHeight={"20px"}
-                          color={(theme: any) => theme.palette.text.primary}>
-                          {selectedLabel.text}
-                        </Typography>
-                        <Typography
-                          fontWeight={400}
-                          fontSize={"12px"}
-                          lineHeight={"16px"}
-                          color={(theme: any) => theme.palette.text.secondary}>
-                          {selectedLabel.helpText}
-                        </Typography>
-                      </Box>
-                    </Stack>
-                  );
-                }
+                const selectedLabel = props.options.find(option => option.value === selected)?.label ?? "";
+                if (typeof selectedLabel === "string") return selectedLabel;
+                return (
+                  <Stack direction={"row"}>
+                    <Box
+                      sx={{
+                        "& svg.MuiSvgIcon-root:not(.MuiSelect-icon)": {
+                          fontSize: "20px",
+                          paddingTop: 0.5,
+                          color: (theme: any) => theme.palette.grey[70],
+                        },
+                      }}>
+                      {selectedLabel.icon}
+                    </Box>
+                    <Box paddingLeft={3}>
+                      <Typography
+                        fontWeight={400}
+                        fontSize={"14px"}
+                        lineHeight={"20px"}
+                        color={(theme: any) => theme.palette.text.primary}>
+                        {selectedLabel.text}
+                      </Typography>
+                      <Typography
+                        fontWeight={400}
+                        fontSize={"12px"}
+                        lineHeight={"16px"}
+                        color={(theme: any) => theme.palette.text.secondary}>
+                        {selectedLabel.helpText}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                );
+              }
               : multiple
-              ? selected => {
+                ? selected => {
                   const itemsSelected = selected as string[];
                   return itemsSelected.length > 1
                     ? `${itemsSelected.length} ${multiSelectedItemName ?? "items"} selected`
                     : props.options.find(option => option.value === itemsSelected?.[0])?.label ?? "";
                 }
-              : selected => props.options.find(option => option.value === selected)?.label ?? "",
+                : selected => props.options.find(option => option.value === selected)?.label ?? "",
           }}
           sx={{
+            ...sx,
             "& .MuiOutlinedInput-root": {
               minWidth: minWidthPx ? `${minWidthPx}px` : "150px",
               height: getHeight(36),

--- a/src/design-system/components/select/index.tsx
+++ b/src/design-system/components/select/index.tsx
@@ -48,6 +48,7 @@ export type SelectProps = {
   multiSelectedItemName?: string;
   minWidthPx?: number;
   heightPx?: number;
+  fontSize?: string;
   sx?: BoxProps["sx"];
 } & Pick<MuiTextFieldProps, "disabled" | "fullWidth" | "size" | "value" | "autoFocus">;
 
@@ -70,6 +71,7 @@ const Select = React.forwardRef(
       defaultValue,
       multiSelectedItemName,
       disabled,
+      fontSize,
       sx,
       ...props
     }: SelectProps,
@@ -157,7 +159,7 @@ const Select = React.forwardRef(
                     <Box paddingLeft={3}>
                       <Typography
                         fontWeight={400}
-                        fontSize={"14px"}
+                        fontSize={fontSize || "14px"}
                         lineHeight={"20px"}
                         color={(theme: any) => theme.palette.text.primary}>
                         {selectedLabel.text}
@@ -189,7 +191,7 @@ const Select = React.forwardRef(
               height: getHeight(36),
               fontStyle: "normal",
               fontWeight: "normal",
-              fontSize: "14px",
+              fontSize: fontSize || "14px",
               lineHeight: "20px",
               backgroundColor: isDark ? theme.palette.grey["10"] : theme.palette.background.default,
               borderRadius: "8px",
@@ -274,7 +276,7 @@ const Select = React.forwardRef(
                   <Box paddingX={1.5} paddingRight={6}>
                     <Typography
                       fontWeight={400}
-                      fontSize={"14px"}
+                      fontSize={fontSize || "14px"}
                       lineHeight={"20px"}
                       color={(theme: any) => theme.palette.text.primary}>
                       {(option.label as LabelType).text}

--- a/src/design-system/components/select/index.tsx
+++ b/src/design-system/components/select/index.tsx
@@ -113,8 +113,7 @@ const Select = React.forwardRef(
         statusText={statusText}
         fullWidth={fullWidth}
         optional={optional}
-        tooltip={tooltip}
-      >
+        tooltip={tooltip}>
         <MuiTextField
           inputRef={ref}
           value={selectedValue}
@@ -142,47 +141,47 @@ const Select = React.forwardRef(
             },
             renderValue: areLabelType
               ? selected => {
-                const selectedLabel = props.options.find(option => option.value === selected)?.label ?? "";
-                if (typeof selectedLabel === "string") return selectedLabel;
-                return (
-                  <Stack direction={"row"}>
-                    <Box
-                      sx={{
-                        "& svg.MuiSvgIcon-root:not(.MuiSelect-icon)": {
-                          fontSize: "20px",
-                          paddingTop: 0.5,
-                          color: (theme: any) => theme.palette.grey[70],
-                        },
-                      }}>
-                      {selectedLabel.icon}
-                    </Box>
-                    <Box paddingLeft={3}>
-                      <Typography
-                        fontWeight={400}
-                        fontSize={fontSize || "14px"}
-                        lineHeight={"20px"}
-                        color={(theme: any) => theme.palette.text.primary}>
-                        {selectedLabel.text}
-                      </Typography>
-                      <Typography
-                        fontWeight={400}
-                        fontSize={"12px"}
-                        lineHeight={"16px"}
-                        color={(theme: any) => theme.palette.text.secondary}>
-                        {selectedLabel.helpText}
-                      </Typography>
-                    </Box>
-                  </Stack>
-                );
-              }
+                  const selectedLabel = props.options.find(option => option.value === selected)?.label ?? "";
+                  if (typeof selectedLabel === "string") return selectedLabel;
+                  return (
+                    <Stack direction={"row"}>
+                      <Box
+                        sx={{
+                          "& svg.MuiSvgIcon-root:not(.MuiSelect-icon)": {
+                            fontSize: "20px",
+                            paddingTop: 0.5,
+                            color: (theme: any) => theme.palette.grey[70],
+                          },
+                        }}>
+                        {selectedLabel.icon}
+                      </Box>
+                      <Box paddingLeft={3}>
+                        <Typography
+                          fontWeight={400}
+                          fontSize={fontSize || "14px"}
+                          lineHeight={"20px"}
+                          color={(theme: any) => theme.palette.text.primary}>
+                          {selectedLabel.text}
+                        </Typography>
+                        <Typography
+                          fontWeight={400}
+                          fontSize={"12px"}
+                          lineHeight={"16px"}
+                          color={(theme: any) => theme.palette.text.secondary}>
+                          {selectedLabel.helpText}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  );
+                }
               : multiple
-                ? selected => {
+              ? selected => {
                   const itemsSelected = selected as string[];
                   return itemsSelected.length > 1
                     ? `${itemsSelected.length} ${multiSelectedItemName ?? "items"} selected`
                     : props.options.find(option => option.value === itemsSelected?.[0])?.label ?? "";
                 }
-                : selected => props.options.find(option => option.value === selected)?.label ?? "",
+              : selected => props.options.find(option => option.value === selected)?.label ?? "",
           }}
           sx={{
             ...sx,

--- a/src/design-system/components/select/select.stories.tsx
+++ b/src/design-system/components/select/select.stories.tsx
@@ -57,6 +57,10 @@ export default {
       defaultValue: undefined,
       control: "number",
     },
+    fontSize: {
+      defaultValue: undefined,
+      control: "string",
+    },
     disabled: {
       defaultValue: false,
       control: "boolean",

--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -174,8 +174,11 @@ const TextField = React.forwardRef(
             endAdornment={
               endAdornment ? (
                 endAdornment
+              ) : loading ? (
+                <CircularProgress thickness={2} color="inherit" size={20} />
               ) : (
-                loading ? <CircularProgress thickness={2} color="inherit" size={20} /> : status && statusIcon[status])
+                status && statusIcon[status]
+              )
             }
             sx={{
               "font": INPUT_TEXT_FONT,
@@ -215,9 +218,9 @@ const TextField = React.forwardRef(
                 opacity: 0.5,
               },
               "&.Mui-disabled:hover .MuiOutlinedInput-notchedOutline, &.Mui-error.Mui-disabled .MuiOutlinedInput-notchedOutline":
-              {
-                borderColor: BORDER_COLOR,
-              },
+                {
+                  borderColor: BORDER_COLOR,
+                },
               "&.Mui-disabled .MuiOutlinedInput-input": {
                 color: (theme: any) => theme.palette.grey["20"],
               },

--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -48,6 +48,7 @@ export type TextFieldProps = {
   rows?: number;
   loading?: boolean;
   maxLength?: number;
+  endAdornment?: ReactNode;
 } & FormControlProps &
   Pick<
     MuiOutlinedInputProps,
@@ -90,6 +91,7 @@ const TextField = React.forwardRef(
       // because most modern browsers ignore "off" https://stackoverflow.com/a/38961567
       autoComplete = "nope",
       "aria-autocomplete": ariaAutocomplete = "none",
+      endAdornment,
       ...props
     }: TextFieldProps,
     ref: any,
@@ -170,7 +172,10 @@ const TextField = React.forwardRef(
             error={hasStatus}
             startAdornment={icon}
             endAdornment={
-              loading ? <CircularProgress thickness={2} color="inherit" size={20} /> : status && statusIcon[status]
+              endAdornment ? (
+                { endAdornment }
+              ) : (
+                loading ? <CircularProgress thickness={2} color="inherit" size={20} /> : status && statusIcon[status])
             }
             sx={{
               "font": INPUT_TEXT_FONT,
@@ -210,9 +215,9 @@ const TextField = React.forwardRef(
                 opacity: 0.5,
               },
               "&.Mui-disabled:hover .MuiOutlinedInput-notchedOutline, &.Mui-error.Mui-disabled .MuiOutlinedInput-notchedOutline":
-                {
-                  borderColor: BORDER_COLOR,
-                },
+              {
+                borderColor: BORDER_COLOR,
+              },
               "&.Mui-disabled .MuiOutlinedInput-input": {
                 color: (theme: any) => theme.palette.grey["20"],
               },

--- a/src/design-system/components/text-field/index.tsx
+++ b/src/design-system/components/text-field/index.tsx
@@ -173,7 +173,7 @@ const TextField = React.forwardRef(
             startAdornment={icon}
             endAdornment={
               endAdornment ? (
-                { endAdornment }
+                endAdornment
               ) : (
                 loading ? <CircularProgress thickness={2} color="inherit" size={20} /> : status && statusIcon[status])
             }


### PR DESCRIPTION
# What does this PR do?

Allows the Component library TextField to have a custom `endAdornment`.
This is required for the inputs below:
![Screenshot 2024-03-12 at 3 11 38 PM](https://github.com/Lightning-AI/lightning-ui/assets/10603793/060955f0-0f90-44f6-a0e8-9d7786c2129f)

Demo of Implementation: https://www.loom.com/share/8ef6273533624800ae455ea49942b36c?sid=e59714fa-4123-4902-8514-7cf67163101a

## Limitations

You cannot both pass an end adornment and inherit the default "Loading" state of inputs that interact with API requests.

## Test Plan

<!--
Write any specific testing instructions for the reviewers.
-->

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [X] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [X] I manually QAed this PR in my local environment
- [X] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
