### PR TITLE
fix(ui): Disabled buttons in dark mode (2/2)

### DIFF
--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -34,7 +34,11 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
   const isPill = props.pill;
   const color = (theme: any) => {
     if (isGreyColor) {
-      return isDark ? theme.palette.common.white : theme.palette.common.black;
+      if (isTextVariant) {
+        return isDark ? theme.palette.common.white : theme.palette.common.black;
+      }
+
+      return theme.palette.common.black;
     }
 
     return isDark ? theme.palette.common.black : theme.palette.common.white;


### PR DESCRIPTION
# What does this PR do?

Following #301, this treats an accidental color change for `color="grey"` buttons found in manual testing after the first PR merged

### Before
<img width="701" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/5404858/2b6f25a2-a5aa-42d7-9a64-2c89ea606c36">

### After
<img width="496" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/5404858/b0c4ca3f-12f3-4d00-82e1-bba0940171a7">

## Test Plan

Covered in previous PR

## Submit checklist

<!--
Check also if some items are not applicable so each PR before merge shall have checked all.
-->

- [x] My PR is focused - addressing only one thing at the time
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- ~I added screenshots featuring related Figma designs and links to the corresponding Figma nodes~
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
