### PR TITLE
fix(Button): disabled grey button should be readable in dark mode

### DIFF
--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -168,7 +168,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
               },
             }),
           "&.Mui-disabled": {
-            opacity: isGreyColor ? 0.3 : 0.5,
+            opacity: isGreyColor ? 1.0 : 0.5,
             color,
             backgroundColor,
           },


### PR DESCRIPTION
# What does this PR do?

This PR removes the weird "opacity" style specified on the "grey" disabled button.

### Now (disabled) – the light mode is unchanged

<img width="172" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/25af89c5-d282-4238-a69b-6c9e0b23bc03">

<img width="174" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/69dc17aa-f6c5-4fb0-9ed7-678836b42550">

### Before (disabled) – the light mode is unchanged

<img width="158" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/fe1ed780-6b1d-4f3f-aaa2-ecdce070c15b">

<img width="174" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/19d1302a-cfc8-4020-ac02-e8b659eb69be">

## Limitations

We may need to adjust the grey button colors further.

## Submit checklist

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
