### PR TITLE
fix(Button): ensure the text-only grey button has the correct disabled state

### DIFF
--- a/src/design-system/components/button/button.stories.tsx
+++ b/src/design-system/components/button/button.stories.tsx
@@ -32,7 +32,7 @@ export default {
       control: "select",
     },
     variant: {
-      options: ["contained", "text"],
+      options: ["outlined", "contained", "text"],
       control: "select",
     },
     cursor: {

--- a/src/design-system/components/button/index.tsx
+++ b/src/design-system/components/button/index.tsx
@@ -168,7 +168,7 @@ const Button = ({ arrow, loading, href, ...props }: ButtonProps) => {
               },
             }),
           "&.Mui-disabled": {
-            opacity: isGreyColor ? 1.0 : 0.5,
+            opacity: isGreyColor ? (isDark && variant === "contained" ? 1.0 : 0.3) : 0.5,
             color,
             backgroundColor,
           },


### PR DESCRIPTION
# What does this PR do?

Follow up to the #303 that makes sure that change in #303 applies only the the great outlined button in the dark mode.

### Now – disabled "text" variant button

<img width="141" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/65781c56-7b5e-4c82-97d1-f92cd6e2a7e7">

### Before – disabled "text" variant button

<img width="145" alt="image" src="https://github.com/Lightning-AI/lightning-ui/assets/4187729/3eb89886-348b-41d9-9ed1-f29eb02db2c5">

### All variants

https://github.com/Lightning-AI/lightning-ui/assets/4187729/09b17212-ec5b-4087-b0e0-f6000058f104

## Limitations

N/A

## Test Plan

Manual validation

## Submit checklist

- [x] My PR is focused - addressing only one thing at the time
- [ ] I wrote new tests \[for a bug or new feature\]
- [x] I manually QAed this PR in my local environment
- [x] I added screenshots or screencasts featuring all UI & UX changes introduced by the PR

### Additional

- I added screenshots featuring related Figma designs and links to the corresponding Figma nodes
- My implementation follows Figma design as close as possible in terms of colors, sizes, margins, proportions, and
  positions
